### PR TITLE
Fix missing docstring and clean up imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Moved all tests to a top-level `tests` package and switched to using the `pytest` runner
+- Added missing parameter in docstring for `apiron.client.ServiceCaller.call`
+- Removed unused imports from `apiron.client`
 
 ## [1.0.0] - 2018-08-01
 ### Added

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -7,8 +7,7 @@ import requests
 from requests import adapters
 from requests.packages.urllib3.util import retry
 
-from apiron.exceptions import NoHostsAvailableException, UnfulfilledParameterException
-from apiron.service.discoverable import DiscoverableService
+from apiron.exceptions import NoHostsAvailableException
 
 LOGGER = logging.getLogger(__name__)
 
@@ -130,6 +129,8 @@ class ServiceCaller:
             The service that hosts the endpoint being called
         :param Endpoint endpoint:
             The endpoint being called
+        :param str method:
+            The HTTP method to use for the call
         :param dict path_kwargs:
             Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
             (default ``None``)


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
* Adds the `method` parameter to the docstring for `ServiceCaller.call`, which was previously missing.
* Removes unused imports from the `apiron.client` module
