### PR TITLE
Add pass-through auth option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Expose pass-through `auth` argument to `requests`
+
 ### Changed
 - Moved all tests to a top-level `tests` package and switched to using the `pytest` runner
 - Added missing parameter in docstring for `apiron.client.ServiceCaller.call`

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -86,6 +86,7 @@ class ServiceCaller:
         data=None,
         headers=None,
         cookies=None,
+        auth=None,
     ):
         host = cls.choose_host(service=service)
 
@@ -104,6 +105,7 @@ class ServiceCaller:
             data=data,
             headers=headers,
             cookies=cookies,
+            auth=auth,
         )
 
         return session.prepare_request(request)
@@ -120,6 +122,7 @@ class ServiceCaller:
         data=None,
         headers=None,
         cookies=None,
+        auth=None,
         retry_spec=DEFAULT_RETRY,
         timeout_spec=DEFAULT_TIMEOUT,
         logger=None,
@@ -153,6 +156,8 @@ class ServiceCaller:
         :param dict cookies:
             Cookies to send to the endpoint
             (default ``None``)
+        :param auth:
+            An object suitable for the :class:`requests.Request` object's ``auth`` argument
         :param urllib3.util.retry.Retry retry_spec:
             (optional)
             An override of the retry behavior for this call.
@@ -190,6 +195,7 @@ class ServiceCaller:
             data=data,
             headers=headers,
             cookies=cookies,
+            auth=auth,
         )
 
         logger.info('{method} {url}'.format(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,6 +47,7 @@ class ClientTestCase(unittest.TestCase):
         data = 'I am a data'
         headers = {'Accept': 'stuff'}
         cookies = {'chocolate-chip': 'yes'}
+        auth = mock.Mock()
 
         mock_get_required_headers.return_value = {'header': 'value'}
         expected_headers = {}
@@ -63,6 +64,7 @@ class ClientTestCase(unittest.TestCase):
                 data=data,
                 headers=headers,
                 cookies=cookies,
+                auth=auth,
             )
 
             mock_request_constructor.assert_called_once_with(
@@ -72,6 +74,7 @@ class ClientTestCase(unittest.TestCase):
                 cookies=cookies,
                 params=params,
                 data=data,
+                auth=auth,
             )
 
             self.assertEqual(1, mock_prepare_request.call_count)


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Resolves #5

**How does this change work?**
Adds an optional `auth` argument to `ServiceCaller.call` that is passed along to the `requests.Request` object unaltered.
