### PR TITLE
Exposed ability to explicitly set the response encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Exposed ability to explicitly set the response encoding
+
 ### Changed
 - Moved all tests to a top-level `tests` package and switched to using the `pytest` runner
 - Added missing parameter in docstring for `apiron.client.ServiceCaller.call`

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -120,6 +120,7 @@ class ServiceCaller:
         data=None,
         headers=None,
         cookies=None,
+        encoding=None,
         retry_spec=DEFAULT_RETRY,
         timeout_spec=DEFAULT_TIMEOUT,
         logger=None,
@@ -152,6 +153,10 @@ class ServiceCaller:
             (default ``None``)
         :param dict cookies:
             Cookies to send to the endpoint
+            (default ``None``)
+        :param str encoding:
+            The codec to use when decoding the response.
+            Default behavior is to have ``requests`` guess the codec.
             (default ``None``)
         :param urllib3.util.retry.Retry retry_spec:
             (optional)
@@ -213,5 +218,8 @@ class ServiceCaller:
             session.close()
 
         response.raise_for_status()
+
+        if encoding:
+            response.encoding = encoding
 
         return endpoint.format_response(response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -187,6 +187,32 @@ class ClientTestCase(unittest.TestCase):
         self.assertFalse(mock_get_adapted_session.called)
         self.assertFalse(session.close.called)
 
+    def test_call_with_explicit_encoding(self):
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+        service.required_headers = {}
+
+        endpoint = mock.Mock()
+        endpoint.required_headers = {}
+        endpoint.get_formatted_path.return_value = '/foo/'
+
+        mock_logger = mock.Mock()
+        mock_response = mock.Mock()
+        mock_response.history = []
+
+        session = mock.Mock()
+        session.send.return_value = mock_response
+
+        ServiceCaller.call(
+            service,
+            endpoint,
+            session=session,
+            logger=mock_logger,
+            encoding='FAKE-CODEC'
+        )
+
+        self.assertEqual('FAKE-CODEC', mock_response.encoding)
+
     def test_build_request_object_raises_no_host_exception(self):
         service = mock.Mock()
         service.get_hosts.return_value = []


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Requests by default will attempt to guess the encoding of the response. Sometimes it guesses incorrectly and prior to this change there was no way to correct the decoded response.

**How does this change work?**
Added `encoding` as an optional keyword argument and when defined will set the encoding on the response
