### PR TITLE
Expose check_for_trailing_slash control in JsonEndpoint

### DIFF
--- a/apiron/endpoint.py
+++ b/apiron/endpoint.py
@@ -145,8 +145,8 @@ class JsonEndpoint(Endpoint):
     An endpoint that returns :mimetype:`application/json`
     """
 
-    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, preserve_order=False):
-        super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params)
+    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, check_for_trailing_slash=None, preserve_order=False):
+        super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params, check_for_trailing_slash=check_for_trailing_slash)
         self.preserve_order = preserve_order
 
     def format_response(self, response):

--- a/apiron/endpoint.py
+++ b/apiron/endpoint.py
@@ -144,8 +144,7 @@ class JsonEndpoint(Endpoint):
     """
     An endpoint that returns :mimetype:`application/json`
     """
-
-    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, check_for_trailing_slash=None, preserve_order=False):
+    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, preserve_order=False, check_for_trailing_slash=True):
         super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params, check_for_trailing_slash=check_for_trailing_slash)
         self.preserve_order = preserve_order
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**

I updated JsonEndpoint to include Endpoint's `check_for_trailing_slash` to pass through to disable the warning. 

**How does this change work?**

`JsonEndpoint` now respects `check_for_trailing_slash` and passes the keyword argument to it's parent class `Endpoint`.

**Additional context**

I am working on a few JSON apis and this change made my Django APIs stop yelling at me ;) 