### PR TITLE
Remove trailing slash checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- The `check_for_trailing_slash` behavior can now be used on `JsonEndpoint`s
+### Removed
+- The `check_for_trailing_slash` argument and default behavior has been removed
 
 ### Changed
 - Service domains and endpoint paths were previously joined per [IETF RCF 1808](https://tools.ietf.org/html/rfc1808.html),

--- a/apiron/endpoint.py
+++ b/apiron/endpoint.py
@@ -13,7 +13,7 @@ class Endpoint:
     A basic service endpoint that responds with the default ``Content-Type`` for that endpoint
     """
 
-    def __init__(self, path='/', default_method='GET', default_params=None, required_params=None, check_for_trailing_slash=True):
+    def __init__(self, path='/', default_method='GET', default_params=None, required_params=None):
         """
         :param str path:
             The URL path for this endpoint, without the protocol or domain
@@ -26,18 +26,8 @@ class Endpoint:
         :param required_params:
             An iterable of required parameter names.
             Calling an endpoint without its required parameters raises an exception.
-        :param bool check_for_trailing_slash:
-            (Default ``True``)
-            Check that this endpoint's path ends with a trailing slash, per the REST standard
         """
         self.default_method = default_method
-
-        if check_for_trailing_slash and not path.split('?')[0].endswith('/'):
-            warnings.warn(
-                'Endpoint path does not end in slash. '
-                'Paths should end with a slash when the endpoint supports it!'.format(path),
-                stacklevel=3
-            )
 
         if '?' in path:
             warnings.warn(
@@ -144,8 +134,8 @@ class JsonEndpoint(Endpoint):
     """
     An endpoint that returns :mimetype:`application/json`
     """
-    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, preserve_order=False, check_for_trailing_slash=True):
-        super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params, check_for_trailing_slash=check_for_trailing_slash)
+    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, preserve_order=False):
+        super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params)
         self.preserve_order = preserve_order
 
     def format_response(self, response):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -48,14 +48,6 @@ class EndpointTestCase(unittest.TestCase):
         path_kwargs = {'one': 'foo', 'two': 'bar', 'three': 'not used'}
         self.assertEqual('/foo/bar/', foo.get_formatted_path(**path_kwargs))
 
-    def test_path_when_doesnt_end_with_slash_and_check_is_on(self):
-        with warnings.catch_warnings(record=True) as warning_records:
-            warnings.simplefilter('always')
-            foo = endpoint.Endpoint(path='/foo')
-            self.assertEqual(1, len(warning_records))
-            self.assertTrue(issubclass(warning_records[-1].category, UserWarning))
-            self.assertEqual('/foo', foo.path)
-
     def test_query_parameter_in_path_generates_warning(self):
         with warnings.catch_warnings(record=True) as warning_records:
             warnings.simplefilter('always')


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Resolves #15 

**How does this change work?**
Removes the `check_for_trailing_slash` arg from `Endpoint` classes (the breaking part of the change) and stops producing `UserWarning`s when an endpoint path does not contain a trailing slash.
