### PR TITLE
Automate artifact deployment to GitHub and PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,51 @@
 language: python
 cache: pip
 python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - '3.4'
+  - '3.5'
+  - '3.6'
 script:
   - pytest --cov=apiron
 install:
   - pip install -r dev-requirements.txt
 notifications:
-    email: false
+  email: false
+before_deploy:
+  python setup.py sdist bdist_wheel
+deploy:
+  - provider: releases
+    api_key:
+      secure: 'AEjhjd5YuhY1wfGEsjd1RELByc7XPKsuyQ+0HBm9vvowQEvfeVIzrJ5/C4rSS5GSYMqv2oFLhU8bssVz/p6XqXqnM73ZoAJe8bIxvYDXdeKMHLSg3HUltbfb4+4VDbgS0/gCs8K4WpAlcAChs3OXoS2ALb9g7R2HkX0rbBqqQczJBi6Gfj6NxpXr7HtRWUnJ08+RBtG8wtjrgY5WQsZuXzlmpyJV0f4/LpRNOiYxnUhyWJQf0gpuvQG/snqoFoT39Sz69HGHls5qYk4QO+I1Kpsy/a0A7vHWZE6jCj+HnCzKFSvgBk/nAQP19Yat6/4ZcooRLtLW81rW2L04OvSE/rWwC+6rrtzNX3eOilbG/Ctwsw1RhQugcIfgKcfMJed+0GpWvtUn5rGNSgx9/xKE9n6oX2l2hVa1rhxAYOYw7RP+bSTmGwL/Cld10bVKOrhIiuMnVUIy/7KlHyfo5Yz84HckZnXGpStKnz5apkx5076axO85vf6R+V6un+Wkwn2ABUB8QvNWObPfLZBb1/a83+pD3FOMAWlKfwC0JzTwzhLhlJ8s2RKwotJP+Fm3/h6Hr6ren6da88v56c4R3gjS4r1RsQPcEQ1MA1Nw74m8fC1ciTG5BLCWeQov6q4H6C6OVmAc14FQe/oNxVyJmKNcllFkpz4dMTkW05PjrwRvqN0='
+    file_glob: true
+    file:
+      - dist/apiron-*-py3-none-any.whl
+      - dist/apiron-*.tar.gz
+    skip_cleanup: true
+    on:
+      repo: ithaka/apiron
+      branch: master
+      tags: true
+      python: '3.4'
+  - provider: pypi
+    server: 'https://test.pypi.org/legacy'
+    user: apiron
+    password:
+      secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
+    skip_cleanup: true
+    skip_existing: true
+    on:
+      repo: ithaka/apiron
+      branch: master
+      tags: true
+      python: '3.4'
+  - provider: pypi
+    user: apiron
+    password:
+      secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
+    skip_cleanup: true
+    skip_existing: true
+    on:
+      repo: ithaka/apiron
+      branch: master
+      tags: true
+      python: '3.4'


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Resolves #3 

**How does this change work?**
Adds `provider` configurations for test.pypi.org, pypi.org, and GitHub releases to `.travis.yml` that upload artifacts only in reaction to tagged releases on the `master` branch of this repository. They only deploy for the Python 3.4 build to avoid trying to make new releases for each Python version tested.

**Additional context**
I created a machine user for GitHub and PyPI whose credentials live canonically with me.
We'll need to find a good place for those to live.