### PR TITLE
Fix PyPI config to avoid redirect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
       tags: true
       python: '3.4'
   - provider: pypi
-    server: 'https://test.pypi.org/legacy'
+    server: 'https://test.pypi.org/legacy/'
     user: apiron
     password:
       secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- End PyPI server URL with a slash to avoid a redirect, allowing deployment of build artifacts during release
+
 ## [2.2.0] - 2019-02-04
 ### Added
 - Automated release artifact deployment via Travis CI's `providers` feature


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Fixes uploading build artifacts to PyPI

**How does this change work?**
Updates the server URL to end in a slash to avoid a redirect, which the tool views as sufficient condition to abort the process
