### PR TITLE
Align tests with pytest style

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,5 +37,5 @@ $ cd /path/to/apiron/
 $ pyenv virtualenv 3.7.0 apiron  # pick your favorite virtual environment tool
 $ pyenv activate apiron  # activate your virtual environment
 (apiron) $ pip install -r dev-requirements.txt
-(apiron) $ pytest --cov=apiron
+(apiron) $ pytest
 ```

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - '3.5'
   - '3.6'
 script:
-  - pytest --cov=apiron
+  - pytest
 install:
   - pip install -r dev-requirements.txt
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `pytest.ini` for `pytest` configuration
+
+### Changed
+- Update tests to use `pytest`-style `assert`s and fixtures (`unittest.mock` usage is still in place, for now)
+- Make `--cov=apiron` the default when running `pytest`
+- Make test output terse by default (`-v` when running restores previous behavior; `-vv` gives explicit test list)
+
 ### Fixed
 - End PyPI server URL with a slash to avoid a redirect, allowing deployment of build artifacts during release
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-pytest-cov==2.6.0
+pytest-cov==2.6.1
 sphinx==1.7.6
 sphinx-autobuild==0.7.1
 twine==1.11.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra -q --cov=apiron --cov-config=.coveragerc

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -1,21 +1,24 @@
-import unittest
+import pytest
 
 from apiron.service.base import Service
 
 
-class ServiceTestCase(unittest.TestCase):
-    def setUp(self):
-        self.service = Service()
-        self.service.domain = 'http://foo.com'
+@pytest.fixture(scope='class')
+def service():
+    service = Service()
+    service.domain = 'http://foo.com'
+    return service
 
-    def test_get_hosts_returns_domain(self):
-        self.assertListEqual(['http://foo.com'], self.service.get_hosts())
 
-    def test_str_method(self):
-        self.assertEqual('http://foo.com', str(self.service))
+class TestService:
+    def test_get_hosts_returns_domain(self, service):
+        assert ['http://foo.com'] == service.get_hosts()
 
-    def test_repr_method(self):
-        self.assertEqual('Service(domain=http://foo.com)', repr(self.service))
+    def test_str_method(self, service):
+        assert 'http://foo.com' == str(service)
 
-    def test_required_hosts_returns_dictionary(self):
-        self.assertDictEqual({}, self.service.required_headers)
+    def test_repr_method(self, service):
+        assert 'Service(domain=http://foo.com)' == repr(service)
+
+    def test_required_hosts_returns_dictionary(self, service):
+        assert {} == service.required_headers

--- a/tests/service/test_discoverable.py
+++ b/tests/service/test_discoverable.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from apiron.service.discoverable import DiscoverableService
 
@@ -14,15 +14,17 @@ class FakeService(DiscoverableService):
     host_resolver_class = FakeResolver
 
 
-class DiscoverableServiceTestCase(unittest.TestCase):
-    def setUp(self):
-        self.service = FakeService()
+@pytest.fixture(scope='class')
+def service():
+    return FakeService()
 
-    def test_get_hosts_returns_hosts_from_resolver(self):
-        self.assertListEqual(['fake'], self.service.get_hosts())
 
-    def test_str_method(self):
-        self.assertEqual('fake-service', str(self.service))
+class TestDiscoverableService:
+    def test_get_hosts_returns_hosts_from_resolver(self, service):
+        assert ['fake'] == service.get_hosts()
 
-    def test_repr_method(self):
-        self.assertEqual('FakeService(service_name=fake-service, host_resolver=FakeResolver)', repr(self.service))
+    def test_str_method(self, service):
+        assert 'fake-service' == str(service)
+
+    def test_repr_method(self, service):
+        assert 'FakeService(service_name=fake-service, host_resolver=FakeResolver)' == repr(service)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import pytest
@@ -6,13 +5,13 @@ import pytest
 from apiron.client import ServiceCaller
 from apiron.exceptions import NoHostsAvailableException
 
-class ClientTestCase(unittest.TestCase):
+class TestClient:
     @mock.patch('requests.sessions.Session', autospec=True)
     def test_get_adapted_session(self, mock_session):
         adapter = mock.Mock()
         adapted_session = ServiceCaller.get_adapted_session(adapter)
-        self.assertEqual(adapter, adapted_session.get_adapter('http://foo.com'))
-        self.assertEqual(adapter, adapted_session.get_adapter('https://foo.com'))
+        assert adapter == adapted_session.get_adapter('http://foo.com')
+        assert adapter == adapted_session.get_adapter('https://foo.com')
 
     def test_get_required_headers(self):
         service = mock.Mock()
@@ -22,7 +21,7 @@ class ClientTestCase(unittest.TestCase):
         expected_headers = {}
         expected_headers.update(service.required_headers)
         expected_headers.update(endpoint.required_headers)
-        self.assertDictEqual(expected_headers, ServiceCaller.get_required_headers(service, endpoint))
+        assert expected_headers == ServiceCaller.get_required_headers(service, endpoint)
 
     @mock.patch('apiron.client.requests.Request')
     @mock.patch('apiron.client.ServiceCaller.get_required_headers')
@@ -79,7 +78,7 @@ class ClientTestCase(unittest.TestCase):
                 auth=auth,
             )
 
-            self.assertEqual(1, mock_prepare_request.call_count)
+            assert 1 == mock_prepare_request.call_count
 
     @mock.patch('apiron.client.Timeout')
     @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
@@ -186,7 +185,7 @@ class ClientTestCase(unittest.TestCase):
 
         expected_response = {'stub': 'response'}
 
-        self.assertDictEqual(actual_response, expected_response)
+        assert expected_response == actual_response
 
 
     @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
@@ -214,8 +213,8 @@ class ClientTestCase(unittest.TestCase):
             logger=mock_logger,
         )
 
-        self.assertFalse(mock_get_adapted_session.called)
-        self.assertFalse(session.close.called)
+        assert not mock_get_adapted_session.called
+        assert not session.close.called
 
     def test_call_with_explicit_encoding(self):
         service = mock.Mock()
@@ -242,25 +241,25 @@ class ClientTestCase(unittest.TestCase):
             encoding='FAKE-CODEC'
         )
 
-        self.assertEqual('FAKE-CODEC', mock_response.encoding)
+        assert 'FAKE-CODEC' == mock_response.encoding
 
     def test_build_request_object_raises_no_host_exception(self):
         service = mock.Mock()
         service.get_hosts.return_value = []
 
-        with self.assertRaises(NoHostsAvailableException):
+        with pytest.raises(NoHostsAvailableException):
             ServiceCaller.build_request_object(None, service, None)
 
     def test_choose_host(self):
         hosts = ['foo', 'bar', 'baz']
         service = mock.Mock()
         service.get_hosts.return_value = hosts
-        self.assertIn(ServiceCaller.choose_host(service), hosts)
+        assert ServiceCaller.choose_host(service) in hosts
 
     def test_choose_host_raises_exception(self):
         service = mock.Mock()
         service.get_hosts.return_value = []
-        with self.assertRaises(NoHostsAvailableException):
+        with pytest.raises(NoHostsAvailableException):
             ServiceCaller.choose_host(service)
 
 @pytest.mark.parametrize('host,path,url', [

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,69 +1,69 @@
 import collections
-import unittest
 import warnings
 from unittest import mock
+
+import pytest
 
 from apiron import endpoint
 from apiron.exceptions import UnfulfilledParameterException
 
 
-class EndpointTestCase(unittest.TestCase):
+class TestEndpoint:
     def test_default_attributes_from_constructor(self):
         foo = endpoint.Endpoint()
-        self.assertEqual('/', foo.path)
-        self.assertEqual('GET', foo.default_method)
+        assert '/' == foo.path
+        assert 'GET' == foo.default_method
 
     def test_constructor_stores_passed_attributes(self):
         foo = endpoint.Endpoint(path='/foo/', default_method='POST')
-        self.assertEqual('/foo/', foo.path)
-        self.assertEqual('POST', foo.default_method)
+        assert '/foo/' == foo.path
+        assert 'POST' == foo.default_method
 
     def test_format_response(self):
         foo = endpoint.Endpoint()
         mock_response = mock.Mock()
         mock_response.text = 'foobar'
-        self.assertEqual('foobar', foo.format_response(mock_response))
+        assert 'foobar' == foo.format_response(mock_response)
 
     def test_required_headers(self):
         foo = endpoint.Endpoint()
-        self.assertDictEqual({}, foo.required_headers)
+        assert {} == foo.required_headers
 
     def test_str_method(self):
         foo = endpoint.Endpoint(path='/foo/bar/')
-        self.assertEqual('/foo/bar/', str(foo))
+        assert '/foo/bar/' == str(foo)
 
     def test_format_path_with_correct_kwargs(self):
         foo = endpoint.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'one': 'foo', 'two': 'bar'}
-        self.assertEqual('/foo/bar/', foo.get_formatted_path(**path_kwargs))
+        assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
 
     def test_format_path_with_incorrect_kwargs(self):
         foo = endpoint.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'foo': 'bar'}
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             foo.get_formatted_path(**path_kwargs)
 
     def test_format_path_with_extra_kwargs(self):
         foo = endpoint.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'one': 'foo', 'two': 'bar', 'three': 'not used'}
-        self.assertEqual('/foo/bar/', foo.get_formatted_path(**path_kwargs))
+        assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
 
     def test_query_parameter_in_path_generates_warning(self):
         with warnings.catch_warnings(record=True) as warning_records:
             warnings.simplefilter('always')
             foo = endpoint.Endpoint(path='/?foo=bar')
-            self.assertEqual(1, len(warning_records))
-            self.assertTrue(issubclass(warning_records[-1].category, UserWarning))
+            assert 1 == len(warning_records)
+            assert issubclass(warning_records[-1].category, UserWarning)
 
     def test_get_merged_params(self):
         foo = endpoint.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
-
-        self.assertDictEqual({'foo': 'bar', 'baz': 'quux'}, foo.get_merged_params({'baz': 'quux'}))
+        assert {'foo': 'bar', 'baz': 'qux'} == foo.get_merged_params({'baz': 'qux'})
 
     def test_get_merged_params_with_unsupplied_param(self):
         foo = endpoint.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
 
-        with self.assertRaises(UnfulfilledParameterException):
+        with pytest.raises(UnfulfilledParameterException):
             foo.get_merged_params(None)
 
     def test_get_merged_params_with_empty_param(self):
@@ -71,24 +71,23 @@ class EndpointTestCase(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as warning_records:
             warnings.simplefilter('always')
-            self.assertDictEqual({'foo': 'bar', 'baz': None}, foo.get_merged_params({'baz': None}))
-            self.assertEqual(1, len(warning_records))
-            self.assertTrue(issubclass(warning_records[-1].category, RuntimeWarning))
+            assert {'foo': 'bar', 'baz': None} == foo.get_merged_params({'baz': None})
+            assert 1 == len(warning_records)
+            assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_get_merged_params_with_required_and_default_param(self):
         foo = endpoint.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'foo'})
+        assert {'foo': 'bar'} == foo.get_merged_params(None)
 
-        self.assertDictEqual({'foo': 'bar'}, foo.get_merged_params(None))
 
-
-class JsonEndpointTestCase(unittest.TestCase):
+class TestJsonEndpoint:
     def test_format_response_when_unordered(self):
         foo = endpoint.JsonEndpoint()
         mock_response = mock.Mock()
 
         with mock.patch.object(mock_response, 'json') as mock_json:
             mock_json.return_value = {'foo': 'bar'}
-            self.assertDictEqual({'foo': 'bar'}, foo.format_response(mock_response))
+            assert {'foo': 'bar'} == foo.format_response(mock_response)
             mock_json.assert_called_once_with(object_pairs_hook=None)
 
     def test_format_response_when_ordered(self):
@@ -97,28 +96,28 @@ class JsonEndpointTestCase(unittest.TestCase):
 
         with mock.patch.object(mock_response, 'json') as mock_json:
             mock_json.return_value = {'foo': 'bar'}
-            self.assertDictEqual({'foo': 'bar'}, foo.format_response(mock_response))
+            assert {'foo': 'bar'} == foo.format_response(mock_response)
             mock_json.assert_called_once_with(object_pairs_hook=collections.OrderedDict)
 
     def test_required_headers(self):
         foo = endpoint.JsonEndpoint()
-        self.assertDictEqual({'Accept': 'application/json'}, foo.required_headers)
+        assert {'Accept': 'application/json'} == foo.required_headers
 
 
-class StreamingEndpointTestCase(unittest.TestCase):
+class TestStreamingEndpoint:
     def test_format_response(self):
         foo = endpoint.StreamingEndpoint()
         mock_response = mock.Mock()
-        self.assertEqual(mock_response.iter_content(chunk_size=None), foo.format_response(mock_response))
+        assert mock_response.iter_content(chunk_size=None) == foo.format_response(mock_response)
 
 
-class StubEndpointTestCase(unittest.TestCase):
+class TestStubEndpoint:
     def test_stub_response(self):
         """
         Test initializing a stub endpoint with a stub response
         """
         stub_endpoint = endpoint.StubEndpoint(stub_response='stub response')
-        self.assertEqual(stub_endpoint.stub_response, 'stub response')
+        assert 'stub response' == stub_endpoint.stub_response
 
     def test_extra_params(self):
         """
@@ -135,4 +134,4 @@ class StubEndpointTestCase(unittest.TestCase):
             'default_params': {'param_name': 'param_val'},
             'required_params': {'param_name'},
         }
-        self.assertDictEqual(stub_endpoint.endpoint_params, expected_params)
+        assert expected_params == stub_endpoint.endpoint_params


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Aligns existing tests with `pytest` style

**How does this change work?**
* Convert `self.assert*Equal(a, b)` to `assert a == b`
* Convert  `setUp`s to fixtures
* Convert `self.assertRaises` to `pytest.raises`

**Additional context**
Also made the output of `pytest` a bit quieter, which can be restored/overridden at the command line
