### PR TITLE
Enable dynamic stub endpoints

### DIFF
--- a/apiron/client.py
+++ b/apiron/client.py
@@ -210,7 +210,18 @@ class ServiceCaller:
                 'Stub call for endpoint defined by {}'
                 .format(getattr(endpoint, 'endpoint_params', {}))
             )
-            return endpoint.stub_response
+            if hasattr(endpoint.stub_response, '__call__'):
+                return endpoint.stub_response(
+                    method=method or endpoint.default_method,
+                    path_kwargs=path_kwargs,
+                    params=params,
+                    data=data,
+                    headers=headers,
+                    cookies=cookies,
+                    auth=auth,
+                )
+            else:
+                return endpoint.stub_response
 
         managing_session = False
 

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -9,7 +9,20 @@ class StubEndpoint:
     def __init__(self, stub_response=None, **kwargs):
         """
         :param stub_response:
-            A pre-baked response, like ``'stub response'`` or ``{'stub': 'response'}``
+            A pre-baked response or response-determining function.
+            Pre-baked response example: ``'stub response'`` or ``{'stub': 'response'}``
+            A response-determining function may operate on any arguments
+            provided to the client's ``call`` method.
+            Example of a response-determining function::
+
+            def stub_response(**kwargs):
+                response_map = {
+                    'param_value': {'stub response': 'for param_key=param_value'},
+                    'default': {'default': 'response'},
+                }
+                data_key = kwargs['params'].setdefault('param_key', 'default')
+                return response_map[data_key]
+
         :param ``**kwargs``:
             Arbitrary parameters that can match the intended real endpoint.
             These don't do anything for the stub but streamline the interface.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -188,6 +188,64 @@ class TestClient:
         assert expected_response == actual_response
 
 
+    @mock.patch('apiron.client.Timeout')
+    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
+    @mock.patch('apiron.client.ServiceCaller.build_request_object')
+    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
+    @mock.patch('requests.Session', autospec=True)
+    def test_call_stub_dynamic(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+        """
+        Test getting a response for a ``StubEndpoint`` using a dynamic response
+        """
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+
+        stub_endpoint = mock.Mock()
+        def stub_response(**kwargs):
+            return 'stub response'
+        stub_endpoint.stub_response = stub_response
+
+        actual_response = ServiceCaller.call(service, stub_endpoint)
+
+        expected_response = 'stub response'
+
+        assert expected_response == actual_response
+
+
+    @mock.patch('apiron.client.Timeout')
+    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
+    @mock.patch('apiron.client.ServiceCaller.build_request_object')
+    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
+    @mock.patch('requests.Session', autospec=True)
+    def test_call_stub_dynamic_params(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+        """
+        Test getting a response for a ``StubEndpoint`` using a dynamic response with parameters
+        """
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+
+        stub_endpoint = mock.Mock()
+        def stub_response(**kwargs):
+            response_map = {
+                'param_value': 'correct',
+                'default': 'incorrect',
+            }
+            data_key = kwargs['params'].setdefault('param_key', 'default')
+            return response_map[data_key]
+
+        stub_endpoint.stub_response = stub_response
+
+        actual_response = ServiceCaller.call(
+            service,
+            stub_endpoint,
+            params={'param_key': 'param_value'}
+        )
+
+        expected_response = 'correct'
+
+        assert expected_response == actual_response
+
+
     @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
     def test_call_with_existing_session(self, mock_get_adapted_session):
         service = mock.Mock()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,86 +166,6 @@ class TestClient:
         )
 
 
-    @mock.patch('apiron.client.Timeout')
-    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
-    @mock.patch('apiron.client.ServiceCaller.build_request_object')
-    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
-    @mock.patch('requests.Session', autospec=True)
-    def test_call_stub(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
-        """
-        Test getting a response for a ``StubEndpoint``
-        """
-        service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
-
-        stub_endpoint = mock.Mock()
-        stub_endpoint.stub_response = {'stub': 'response'}
-
-        actual_response = ServiceCaller.call(service, stub_endpoint)
-
-        expected_response = {'stub': 'response'}
-
-        assert expected_response == actual_response
-
-
-    @mock.patch('apiron.client.Timeout')
-    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
-    @mock.patch('apiron.client.ServiceCaller.build_request_object')
-    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
-    @mock.patch('requests.Session', autospec=True)
-    def test_call_stub_dynamic(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
-        """
-        Test getting a response for a ``StubEndpoint`` using a dynamic response
-        """
-        service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
-
-        stub_endpoint = mock.Mock()
-        def stub_response(**kwargs):
-            return 'stub response'
-        stub_endpoint.stub_response = stub_response
-
-        actual_response = ServiceCaller.call(service, stub_endpoint)
-
-        expected_response = 'stub response'
-
-        assert expected_response == actual_response
-
-
-    @mock.patch('apiron.client.Timeout')
-    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
-    @mock.patch('apiron.client.ServiceCaller.build_request_object')
-    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
-    @mock.patch('requests.Session', autospec=True)
-    def test_call_stub_dynamic_params(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
-        """
-        Test getting a response for a ``StubEndpoint`` using a dynamic response with parameters
-        """
-        service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
-
-        stub_endpoint = mock.Mock()
-        def stub_response(**kwargs):
-            response_map = {
-                'param_value': 'correct',
-                'default': 'incorrect',
-            }
-            data_key = kwargs['params'].setdefault('param_key', 'default')
-            return response_map[data_key]
-
-        stub_endpoint.stub_response = stub_response
-
-        actual_response = ServiceCaller.call(
-            service,
-            stub_endpoint,
-            params={'param_key': 'param_value'}
-        )
-
-        expected_response = 'correct'
-
-        assert expected_response == actual_response
-
-
     @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
     def test_call_with_existing_session(self, mock_get_adapted_session):
         service = mock.Mock()
@@ -319,6 +239,79 @@ class TestClient:
         service.get_hosts.return_value = []
         with pytest.raises(NoHostsAvailableException):
             ServiceCaller.choose_host(service)
+
+
+@mock.patch('apiron.client.Timeout')
+@mock.patch('apiron.client.ServiceCaller.get_adapted_session')
+@mock.patch('apiron.client.ServiceCaller.build_request_object')
+@mock.patch('requests.adapters.HTTPAdapter', autospec=True)
+@mock.patch('requests.Session', autospec=True)
+class TestClientStubCall:
+
+    def test_call_stub(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+        """
+        Test getting a response for a ``StubEndpoint``
+        """
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+
+        stub_endpoint = mock.Mock()
+        stub_endpoint.stub_response = {'stub': 'response'}
+
+        actual_response = ServiceCaller.call(service, stub_endpoint)
+
+        expected_response = {'stub': 'response'}
+
+        assert expected_response == actual_response
+
+
+    def test_call_stub_dynamic(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+        """
+        Test getting a response for a ``StubEndpoint`` using a dynamic response
+        """
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+
+        stub_endpoint = mock.Mock()
+        def stub_response(**kwargs):
+            return 'stub response'
+        stub_endpoint.stub_response = stub_response
+
+        actual_response = ServiceCaller.call(service, stub_endpoint)
+
+        expected_response = 'stub response'
+
+        assert expected_response == actual_response
+
+
+    def test_call_stub_dynamic_params(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+        """
+        Test getting a response for a ``StubEndpoint`` using a dynamic response with parameters
+        """
+        service = mock.Mock()
+        service.get_hosts.return_value = ['http://host1.biz']
+
+        stub_endpoint = mock.Mock()
+        def stub_response(**kwargs):
+            response_map = {
+                'param_value': 'correct',
+                'default': 'incorrect',
+            }
+            data_key = kwargs['params'].setdefault('param_key', 'default')
+            return response_map[data_key]
+
+        stub_endpoint.stub_response = stub_response
+
+        actual_response = ServiceCaller.call(
+            service,
+            stub_endpoint,
+            params={'param_key': 'param_value'}
+        )
+
+        expected_response = 'correct'
+
+        assert expected_response == actual_response
+
 
 @pytest.mark.parametrize('host,path,url', [
     ('http://biz.com', '/endpoint', 'http://biz.com/endpoint'),


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?

**What does this change address?**
Enable a stub endpoint to yield different responses based on input when calling.

**How does this change work?**
A `StubEndpiont` can be created by setting the `stub_response` to a response-determining function. That function can use input given to the client's `call` method to determine a response. E.g., you can get different responses by using different url parameters.
