### PR TITLE
Fix backward compatibility for StubEndpoint

### DIFF
--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -1,13 +1,12 @@
-from apiron.endpoint.endpoint import Endpoint
-
-
-class StubEndpoint(Endpoint):
+class StubEndpoint:
     """
     A stub endpoint designed to return a pre-baked response
 
     The intent is to allow for a service to be implemented
     before the endpoint is complete.
     """
+    def __call__(self, **kwargs):
+        return self.stub_response(**kwargs) if callable(self.stub_response) else self.stub_response
 
     def __init__(self, stub_response=None, **kwargs):
         """
@@ -30,4 +29,3 @@ class StubEndpoint(Endpoint):
         """
         self.endpoint_params = kwargs or {}
         self.stub_response = stub_response or 'stub for {}'.format(self.endpoint_params)
-        super().__init__(**kwargs)

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from apiron.client import ServiceCaller
-from apiron.endpoint import Endpoint, StubEndpoint
+from apiron.endpoint import Endpoint
 
 
 class ServiceMeta(type):

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from apiron.client import ServiceCaller
-from apiron.endpoint import Endpoint
+from apiron.endpoint import Endpoint, StubEndpoint
 
 
 class ServiceMeta(type):


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
An update to the way `StubEndpoint`s are handled resulted in an
inadvertent limiting of the previously allowed API, potentially breaking
code that was stubbing a `JsonEndpoint` in particular.

`StubEndpoint`s making use of the `preserve_order` keyword argument
previously only passed that along to their own `stub_response` method,
if any, but after the change tried to pass it along to the `Endpoint`
base class' constructor, which does not accept such an argument.

**How does this change work?**
This solution instead makes `StubEndpoint`s directly callable, much the
same way real endpoints are made callable. This allows known
use cases to continue working while also making sure the original bug
where `StubEndpoint`s were not callable remains fixed.