### PR TITLE
Fix backward compatibility for StubEndpoint

### DIFF
--- a/apiron/client.py
+++ b/apiron/client.py
@@ -212,7 +212,7 @@ class ServiceCaller:
             )
             if callable(endpoint.stub_response):
                 return endpoint.stub_response(
-                    method=method or endpoint.default_method,
+                    method=method or getattr(endpoint, 'default_method', 'GET'),
                     path_kwargs=path_kwargs,
                     params=params,
                     data=data,

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -1,13 +1,21 @@
-from apiron.endpoint.endpoint import Endpoint
-
-
-class StubEndpoint(Endpoint):
+class StubEndpoint:
     """
     A stub endpoint designed to return a pre-baked response
 
     The intent is to allow for a service to be implemented
     before the endpoint is complete.
     """
+
+    def __call__(self, *args, **kwargs):
+        """
+        Used to provide syntax sugar on top of :func:`apiron.client.ServiceCaller.call`.
+        The callable attribute is set dynamically by the :class:`Service` subclass this endpoint is a part of.
+        Arguments are identical to those of :func:`apiron.client.ServiceCaller.call`
+        """
+        if hasattr(self, 'callable'):
+            return self.callable(*args, **kwargs)
+        else:
+            raise TypeError('Endpoints are only callable in conjunction with a Service class.')
 
     def __init__(self, stub_response=None, **kwargs):
         """
@@ -30,4 +38,3 @@ class StubEndpoint(Endpoint):
         """
         self.endpoint_params = kwargs or {}
         self.stub_response = stub_response or 'stub for {}'.format(self.endpoint_params)
-        super().__init__(**kwargs)

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from apiron.client import ServiceCaller
-from apiron.endpoint import Endpoint
+from apiron.endpoint import Endpoint, StubEndpoint
 
 
 class ServiceMeta(type):
@@ -11,7 +11,7 @@ class ServiceMeta(type):
 
     def __getattribute__(cls, *args):
         attribute = type.__getattribute__(cls, *args)
-        if isinstance(attribute, Endpoint):
+        if isinstance(attribute, Endpoint) or isinstance(attribute, StubEndpoint):
             attribute.callable = partial(ServiceCaller.call, cls, attribute)
         return attribute
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -144,11 +144,13 @@ class TestStubEndpoint:
             path='/some/path/',
             default_params={'param_name': 'param_val'},
             required_params={'param_name'},
+            arbitrary_kwarg='foo',
         )
         expected_params = {
             'path': '/some/path/',
             'default_params': {'param_name': 'param_val'},
             'required_params': {'param_name'},
+            'arbitrary_kwarg': 'foo',
         }
         assert expected_params == stub_endpoint.endpoint_params
 
@@ -186,3 +188,8 @@ class TestStubEndpoint:
             call_kwargs={'params': {'param_key': 'param_value'}},
             expected_response={'stub response': 'for param_key=param_value'},
         )
+
+    def test_call_without_service_raises_exception(self, service):
+        stub_endpoint = apiron.StubEndpoint(stub_response='foo')
+        with pytest.raises(TypeError):
+            stub_endpoint()


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
An update to the way `StubEndpoint`s are handled resulted in an
inadvertent limiting of the previously allowed API, potentially breaking
code that was stubbing a `JsonEndpoint` in particular.

I found this due to a use case regarding `preserve_order`.
`StubEndpoint`s making use of the `preserve_order` keyword argument
previously only passed that along to their own `stub_response` method,
if any, but after the change tried to pass it along to the `Endpoint`
base class' constructor, which does not accept such an argument.

**How does this change work?**
This solution instead makes `StubEndpoint`s directly callable, much the
same way real endpoints are made callable. This allows known
use cases to continue working while also making sure the original bug
where `StubEndpoint`s were not callable remains fixed.

**Additional context**
I updated an existing test to exercise the bug, adding an additional
test to make sure `StubEndpoint`s behave appropriately when attempting
to call them without being attached to a `Service`.
