### PR TITLE
Introspect path kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Ability to use regulard keyword arguments when calling an endpoint (instead of `path_kwargs`)
+
 ## [2.4.0] - 2019-04-09
 ### Changed
 - Simplify imports so that all commonly-used classes can be imported with `from apiron import <class>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Ability to use regulard keyword arguments when calling an endpoint (instead of `path_kwargs`)
+- Ability to use regular keyword arguments when calling an endpoint (instead of `path_kwargs`)
 
 ## [2.4.0] - 2019-04-09
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ class GitHub(Service):
 Once your service definition is in place, you can interact with its endpoints:
 
 ```python
-response = GitHub.user(
-    path_kwargs={'username': 'defunkt'},
-)  # {"name": "Chris Wanstrath", ...}
+response = GitHub.user(username='defunkt')
+# {"name": "Chris Wanstrath", ...}
 
-response = GitHub.repo(
-    path_kwargs={'org': 'github', 'repo': 'hub'},
-)  # {"description": "hub helps you win at git.", ...}
+response = GitHub.repo(org='github', repo='hub')
+# {"description": "hub helps you win at git.", ...}
 ```
 
 To learn more about building clients, head over to [the docs](https://apiron.readthedocs.io).

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -108,10 +108,12 @@ class ServiceCaller:
         headers=None,
         cookies=None,
         auth=None,
+        **kwargs
     ):
         host = cls.choose_host(service=service)
 
         path_kwargs = path_kwargs or {}
+        path_kwargs.update(**kwargs)
         path = endpoint.get_formatted_path(**path_kwargs)
 
         merged_params = endpoint.get_merged_params(params)
@@ -148,6 +150,7 @@ class ServiceCaller:
         retry_spec=DEFAULT_RETRY,
         timeout_spec=DEFAULT_TIMEOUT,
         logger=None,
+        **kwargs
     ):
         """
         :param Service service:
@@ -240,6 +243,7 @@ class ServiceCaller:
             headers=headers,
             cookies=cookies,
             auth=auth,
+            **kwargs
         )
 
         logger.info('{method} {url}'.format(

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import random
+import warnings
 from urllib import parse
 
 import requests
@@ -112,6 +113,14 @@ class ServiceCaller:
     ):
         host = cls.choose_host(service=service)
 
+        if path_kwargs:
+            warnings.warn(
+                'path_kwargs is no longer necessary and will be removed in a future version of apiron. '
+                'You can call endpoints using plain keyword arguments instead!',
+                RuntimeWarning,
+                stacklevel=4
+            )
+            
         path_kwargs = path_kwargs or {}
         path_kwargs.update(**kwargs)
         path = endpoint.get_formatted_path(**path_kwargs)

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -120,7 +120,7 @@ class ServiceCaller:
                 RuntimeWarning,
                 stacklevel=4
             )
-            
+
         path_kwargs = path_kwargs or {}
         path_kwargs.update(**kwargs)
         path = endpoint.get_formatted_path(**path_kwargs)

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -1,4 +1,5 @@
 import logging
+import string
 import warnings
 
 from apiron.exceptions import UnfulfilledParameterException
@@ -85,7 +86,27 @@ class Endpoint:
         :rtype:
             str
         """
+        self._validate_path_placeholders(self.path_placeholders, kwargs)
+
         return self.path.format(**kwargs)
+
+    @property
+    def path_placeholders(self):
+        parser = string.Formatter()
+        return [
+            placeholder_name
+            for _, placeholder_name, _, _ in parser.parse(self.path)
+            if placeholder_name
+        ]
+
+    def _validate_path_placeholders(self, placeholder_names, path_kwargs):
+        if any(path_kwarg not in placeholder_names for path_kwarg in path_kwargs):
+            warnings.warn(
+                'An unknown path kwarg was supplied to {}. '
+                'kwargs supplied: {}'.format(self, path_kwargs),
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def get_merged_params(self, supplied_params=None):
         """

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -92,6 +92,16 @@ class Endpoint:
 
     @property
     def path_placeholders(self):
+        """
+        The formattable placeholders from this endpoint's path, in the order they appear.
+
+        Example:
+
+            >>> endpoint = Endpoint(path='/api/{foo}/{bar}')
+            >>> endpoint.path_placeholders
+            ['foo', 'bar']
+        """
+
         parser = string.Formatter()
         return [
             placeholder_name

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -105,7 +105,7 @@ class Endpoint:
                 'An unknown path kwarg was supplied to {}. '
                 'kwargs supplied: {}'.format(self, path_kwargs),
                 RuntimeWarning,
-                stacklevel=2,
+                stacklevel=6,
             )
 
     def get_merged_params(self, supplied_params=None):
@@ -137,7 +137,7 @@ class Endpoint:
                     empty_params=empty_params,
                 ),
                 RuntimeWarning,
-                stacklevel=4,
+                stacklevel=5,
             )
 
         unfulfilled_params = {

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+pytest==4.2.0
 pytest-cov==2.6.1
 sphinx==1.7.6
 sphinx-autobuild==0.7.1

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -46,11 +46,11 @@ Using all the features
     HttpBin.poster(data={'foo': 'bar'})
 
     # A GET call with parameters formatted into the path
-    HttpBin.anything(path_kwargs={'anything': 42})
+    HttpBin.anything(anything=42)
 
     # A GET call with a 500 response, raises RetryError since we successfully tried but got a bad response
     try:
-        HttpBin.status(path_kwargs={'status_code': 500})
+        HttpBin.status(status_code=500)
     except requests.exceptions.RetryError:
         pass
 
@@ -66,7 +66,7 @@ Using all the features
     )
 
     # A streaming response
-    response = HttpBin.streamer(path_kwargs={'num_lines': 20})
+    response = HttpBin.streamer(num_lines=20)
     for chunk in response:
         print(chunk)
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -38,13 +38,11 @@ using the :class:`ServiceCaller <apiron.client.ServiceCaller>`:
 
 .. code-block:: python
 
-    response = GitHub.user(
-        path_kwargs={'username': 'defunkt'},
-    )  # {"name": "Chris Wanstrath", ...}
+    response = GitHub.user(username='defunkt')
+    # {"name": "Chris Wanstrath", ...}
 
-    response = GitHub.repo(
-        path_kwargs={'org': 'github', 'repo': 'hub'},
-    )  # {"description": "hub helps you win at git.", ...}
+    response = GitHub.repo(org='github', repo='hub')
+    # {"description": "hub helps you win at git.", ...}
 
 
 **********

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from apiron import ServiceCaller, NoHostsAvailableException
 
+
 class TestClient:
     @mock.patch('requests.sessions.Session', autospec=True)
     def test_get_adapted_session(self, mock_session):
@@ -41,7 +42,6 @@ class TestClient:
         endpoint.default_params = {}
         endpoint.required_params = set()
 
-        path_kwargs = {'foo': 'bar'}
         params = {'baz': 'qux'}
         endpoint.get_merged_params.return_value = params
         data = 'I am a data'
@@ -59,12 +59,12 @@ class TestClient:
                 session,
                 service,
                 endpoint,
-                path_kwargs=path_kwargs,
                 params=params,
                 data=data,
                 headers=headers,
                 cookies=cookies,
                 auth=auth,
+                foo='bar',
             )
 
             mock_request_constructor.assert_called_once_with(

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -48,6 +48,14 @@ class TestEndpoint:
         foo = apiron.Endpoint(path='/foo/bar/')
         assert '/foo/bar/' == str(foo)
 
+    def test_path_placeholders_when_none_present(self):
+        foo = apiron.Endpoint()
+        assert [] == foo.path_placeholders
+
+    def test_path_placeholders_when_present(self):
+        foo = apiron.Endpoint(path='/foo/{one}/{two}')
+        assert ['one', 'two'] == foo.path_placeholders
+
     def test_format_path_with_correct_kwargs(self):
         foo = apiron.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'one': 'foo', 'two': 'bar'}
@@ -58,6 +66,7 @@ class TestEndpoint:
         path_kwargs = {'foo': 'bar'}
         with pytest.raises(KeyError):
             with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter('always')
                 foo.get_formatted_path(**path_kwargs)
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, RuntimeWarning)
@@ -100,6 +109,15 @@ class TestEndpoint:
         foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'foo'})
         assert {'foo': 'bar'} == foo.get_merged_params()
 
+    @mock.patch('apiron.client.requests.Session.send')
+    def test_using_path_kwargs_produces_warning(self, mock_send, service):
+        service.foo = apiron.Endpoint(path='/foo/{one}')
+        with warnings.catch_warnings(record=True) as warning_records:
+            warnings.simplefilter('always')
+            _ = service.foo(path_kwargs={'one': 'bar'})
+            assert 1 == len(warning_records)
+            assert issubclass(warning_records[-1].category, RuntimeWarning)
+
 
 class TestJsonEndpoint:
     def test_format_response_when_unordered(self):
@@ -133,7 +151,6 @@ class TestStreamingEndpoint:
 
 
 class TestStubEndpoint:
-
     def test_stub_response(self):
         """
         Test initializing a stub endpoint with a stub response

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -57,12 +57,18 @@ class TestEndpoint:
         foo = apiron.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'foo': 'bar'}
         with pytest.raises(KeyError):
-            foo.get_formatted_path(**path_kwargs)
+            with warnings.catch_warnings(record=True) as warning_records:
+                foo.get_formatted_path(**path_kwargs)
+            assert 1 == len(warning_records)
+            assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_format_path_with_extra_kwargs(self):
         foo = apiron.Endpoint(path='/{one}/{two}/')
         path_kwargs = {'one': 'foo', 'two': 'bar', 'three': 'not used'}
-        assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
+        with warnings.catch_warnings(record=True) as warning_records:
+            assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
+            assert 1 == len(warning_records)
+            assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_query_parameter_in_path_generates_warning(self):
         with warnings.catch_warnings(record=True) as warning_records:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -73,7 +73,7 @@ class TestEndpoint:
     def test_query_parameter_in_path_generates_warning(self):
         with warnings.catch_warnings(record=True) as warning_records:
             warnings.simplefilter('always')
-            foo = apiron.Endpoint(path='/?foo=bar')
+            _ = apiron.Endpoint(path='/?foo=bar')
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, UserWarning)
 
@@ -85,7 +85,7 @@ class TestEndpoint:
         foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
 
         with pytest.raises(apiron.UnfulfilledParameterException):
-            foo.get_merged_params(None)
+            foo.get_merged_params()
 
     def test_get_merged_params_with_empty_param(self):
         foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
@@ -98,7 +98,7 @@ class TestEndpoint:
 
     def test_get_merged_params_with_required_and_default_param(self):
         foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'foo'})
-        assert {'foo': 'bar'} == foo.get_merged_params(None)
+        assert {'foo': 'bar'} == foo.get_merged_params()
 
 
 class TestJsonEndpoint:
@@ -195,7 +195,7 @@ class TestStubEndpoint:
             expected_response={'stub response': 'for param_key=param_value'},
         )
 
-    def test_call_without_service_raises_exception(self, service):
+    def test_call_without_service_raises_exception(self):
         stub_endpoint = apiron.StubEndpoint(stub_response='foo')
         with pytest.raises(TypeError):
             stub_endpoint()


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [x] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Resolves #46 

**How does this change work?**
By passing any additional `kwargs` sent to `ServiceCaller.call` along to the endpoint formatting the same way `path_kwargs` currently happens, existing explicit keyword arguments continue working while enabling the endpoint's `__call__` to use the additional keyword arguments as if they were `path_kwargs`.

**Additional context**
This is fully backward compatible since there was previously an explicit, finite list of keyword arguments being considered by `ServiceCaller.call` previously; any additional keyword arguments produce strictly a superset of the previous arguments. In a future (breaking) version, we may want to yell more loudly when a keyword argument that doesn't match a path kwarg is passed to the endpoint. 

This change does mean that any arbitrary keyword arguments that need to be used for a different purpose may need to do some gymnastics later on. It feels okay for the present but I'm open to suggestions in that area.