### PR TITLE
Improve inheritance structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.0] - 2019-04-09
 ### Changed
 - Simplify imports so that all commonly-used classes can be imported with `from apiron import <class>`
+- `DiscoverableService` now inherits from `ServiceBase`, an ancestor common with `Service`, instead of `Service` itself
 
 ### Fixed
 - Error in calling a dynamic stub endpoint

--- a/apiron/service/__init__.py
+++ b/apiron/service/__init__.py
@@ -1,8 +1,9 @@
-from apiron.service.base import Service
+from apiron.service.base import Service, ServiceBase
 from apiron.service.discoverable import DiscoverableService
 
 
 __all__ = [
     'Service',
+    'ServiceBase',
     'DiscoverableService',
 ]

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -16,28 +16,37 @@ class ServiceMeta(type):
         return attribute
 
     def __str__(cls):
-        service_name = getattr(cls, 'service_name', None)
-        return service_name or cls.domain
+        return str(cls())
 
     def __repr__(cls):
-        if hasattr(cls, 'service_name'):
-            return '{klass}(service_name={service_name}, host_resolver={host_resolver})'.format(
-                klass=cls.__name__,
-                service_name=cls.service_name,
-                host_resolver=cls.host_resolver_class.__name__,
-            )
-        else:
-            return '{klass}(domain={domain})'.format(klass=cls.__name__, domain=cls.domain)
+        return repr(cls())
 
 
-class Service(metaclass=ServiceMeta):
+class ServiceBase(metaclass=ServiceMeta):
+    required_headers = {}
+
+    @classmethod
+    def get_hosts(cls):
+        """
+        The fully-qualified hostnames that correspond to this service.
+        These are often determined by asking a load balancer or service discovery mechanism.
+
+        :return:
+            The hostname strings corresponding to this service
+        :rtype:
+            list
+        """
+        return []
+
+
+class Service(ServiceBase):
     """
     A base class for low-level services.
 
     A service has a domain off of which one or more endpoints stem.
     """
 
-    required_headers = {}
+    domain = None
 
     @classmethod
     def get_hosts(cls):
@@ -53,7 +62,7 @@ class Service(metaclass=ServiceMeta):
         return [cls.domain]
 
     def __str__(self):
-        return str(self.__class__)
+        return self.__class__.domain
 
     def __repr__(self):
-        return repr(self.__class__)
+        return '{klass}(domain={domain})'.format(klass=self.__class__.__name__, domain=self.__class__.domain)

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -46,8 +46,6 @@ class Service(ServiceBase):
     A service has a domain off of which one or more endpoints stem.
     """
 
-    domain = None
-
     @classmethod
     def get_hosts(cls):
         """

--- a/apiron/service/discoverable.py
+++ b/apiron/service/discoverable.py
@@ -9,16 +9,13 @@ class DiscoverableService(ServiceBase):
     and returns a list of host names that correspond to that service.
     """
 
-    service_name = None
-    host_resolver_class = None
-
     @classmethod
     def get_hosts(cls):
         return cls.host_resolver_class.resolve(cls.service_name)
-    
+
     def __str__(self):
         return self.service_name
-    
+
     def __repr__(self):
         klass = self.__class__
         return '{klass}(service_name={service_name}, host_resolver={host_resolver})'.format(

--- a/apiron/service/discoverable.py
+++ b/apiron/service/discoverable.py
@@ -1,20 +1,28 @@
-from apiron.service.base import Service
+from apiron.service.base import ServiceBase
 
 
-class DiscoverableService(Service):
+class DiscoverableService(ServiceBase):
     """
     A Service whose hosts are determined via a host resolver.
     A host resolver is any class with a :func:`resolve` method
-    that takes a service name as its sole argument and returns a
-    list of host names that correspond to that service.
+    that takes a service name as its sole argument
+    and returns a list of host names that correspond to that service.
     """
+
+    service_name = None
+    host_resolver_class = None
 
     @classmethod
     def get_hosts(cls):
         return cls.host_resolver_class.resolve(cls.service_name)
-
+    
     def __str__(self):
-        return str(self.__class__)
-
+        return self.service_name
+    
     def __repr__(self):
-        return repr(self.__class__)
+        klass = self.__class__
+        return '{klass}(service_name={service_name}, host_resolver={host_resolver})'.format(
+            klass=klass.__name__,
+            service_name=klass.service_name,
+            host_resolver=klass.host_resolver_class.__name__,
+        )

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apiron import Service
+from apiron import Service, ServiceBase
 
 
 @pytest.fixture(scope='class')
@@ -8,6 +8,13 @@ def service():
     class SomeService(Service):
         domain = 'http://foo.com'
     return SomeService
+
+class TestServiceBase:
+    def test_get_hosts_returns_empty_list_by_default(self):
+        assert [] == ServiceBase.get_hosts()
+
+    def test_required_headers_returns_empty_dict_by_default(self, service):
+        assert {} == service.required_headers
 
 
 class TestService:
@@ -26,5 +33,5 @@ class TestService:
     def test_repr_method_on_instance(self, service):
         assert 'SomeService(domain=http://foo.com)' == repr(service())
 
-    def test_required_hosts_returns_dictionary(self, service):
+    def test_required_headers_returns_empty_dict_by_default(self, service):
         assert {} == service.required_headers


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Before this change, `Service` and `DiscoverableService` were tightly coupled, and `DiscoverableService` overrode most of the behavior explicitly defined in `Service`.

**How does this change work?**
It makes more sense that these classes both inherit from some shared ancestor (called `ServiceBase` here), and specialize only what differs, i.e. `get_hosts`, `__str__`, `__repr__`, and the differing behavior between `domain` and `service_name` for each respectively.

**Additional context**
This allowed `ServiceMeta` to know less about the classes that derive from it.
