### PR TITLE
Forward the `json` kwarg to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Ability to pass dict to `json` keyword argument for raw POST body instead of form-encoded data
 - Ability to use regular keyword arguments when calling an endpoint (instead of `path_kwargs`)
 
 ## [2.4.0] - 2019-04-09

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -106,6 +106,7 @@ class ServiceCaller:
         path_kwargs=None,
         params=None,
         data=None,
+        json=None,
         headers=None,
         cookies=None,
         auth=None,
@@ -135,6 +136,7 @@ class ServiceCaller:
             url=cls.build_url(host, path),
             params=merged_params,
             data=data,
+            json=json,
             headers=headers,
             cookies=cookies,
             auth=auth,
@@ -152,6 +154,7 @@ class ServiceCaller:
         session=None,
         params=None,
         data=None,
+        json=None,
         headers=None,
         cookies=None,
         auth=None,
@@ -183,6 +186,10 @@ class ServiceCaller:
             (optional)
             ``POST`` data to send to the endpoint.
             A :class:`dict` will be form-encoded, while a :class:`str` will be sent raw
+            (default ``None``)
+        :param dict json:
+            (optional)
+            A JSON-serializable dictionary that will be sent as the ``POST`` body
             (default ``None``)
         :param dict headers:
             HTTP Headers to send to the endpoint
@@ -228,6 +235,7 @@ class ServiceCaller:
                     path_kwargs=path_kwargs,
                     params=params,
                     data=data,
+                    json=json,
                     headers=headers,
                     cookies=cookies,
                     auth=auth,
@@ -249,6 +257,7 @@ class ServiceCaller:
             path_kwargs=path_kwargs,
             params=params,
             data=data,
+            json=json,
             headers=headers,
             cookies=cookies,
             auth=auth,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,7 @@ class TestClient:
         params = {'baz': 'qux'}
         endpoint.get_merged_params.return_value = params
         data = 'I am a data'
+        json = {'raw': 'data'}
         headers = {'Accept': 'stuff'}
         cookies = {'chocolate-chip': 'yes'}
         auth = mock.Mock()
@@ -61,6 +62,7 @@ class TestClient:
                 endpoint,
                 params=params,
                 data=data,
+                json=json,
                 headers=headers,
                 cookies=cookies,
                 auth=auth,
@@ -74,6 +76,7 @@ class TestClient:
                 cookies=cookies,
                 params=params,
                 data=data,
+                json=json,
                 auth=auth,
             )
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Resolves #50 

In addition to `data`, `requests` accepts a `json` kwarg that allows you
to pass in a `dict` that will eventually be serialized into a JSON POST
body (as compared to `data`, which gets form-encoded first). This was an
oversight in the initial implementation since that wasn't a use case for us
at the time.

**How does this change work?**
Pass `json` kwarg along to `requests` the same way `params`, `data`, et al. are currently

**Additional context**
This would be a breaking change if #48 were released already, as it would remove `json` as a possibility for `path_kwargs` and start sending it along to `requests`. Since that has not been released yet, I don't believe there's a negative impact since current users must all still be using `path_kwargs`.
