### PR TITLE
Add linting stage to Travis CI build

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,3 +39,15 @@ $ pyenv activate apiron  # activate your virtual environment
 (apiron) $ pip install -r dev-requirements.txt
 (apiron) $ pytest
 ```
+
+## Code formatting
+
+This project uses [`black`](https://github.com/ambv/black) for consistent code formatting.
+Before opening a pull request, try to remember to run `black` on your code.
+Since we support Python versions as early as 3.4, the following command should be used to format your code:
+
+```
+$ black --target py34 apiron tests
+```
+
+Note that `black` requires Python 3.6+ to run, although it supports formatting compatible with earlier versions of Python.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,11 +43,5 @@ $ pyenv activate apiron  # activate your virtual environment
 ## Code formatting
 
 This project uses [`black`](https://github.com/ambv/black) for consistent code formatting.
-Before opening a pull request, try to remember to run `black` on your code.
-Since we support Python versions as early as 3.4, the following command should be used to format your code:
-
-```
-$ black --target py34 apiron tests
-```
-
+Before opening a pull request, try to remember to run `black` on your code; the build will fail otherwise.
 Note that `black` requires Python 3.6+ to run, although it supports formatting compatible with earlier versions of Python.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ notifications:
   email: false
 
 python:
-  - '3.4'
-  - '3.5'
-  - '3.6'
   - '3.7'
+  - '3.6'
+  - '3.5'
+  - '3.4'
 
 install:
   - pip install -r dev-requirements.txt
 
 stages:
-  - lint
+  - name: lint
   - test
   - name: deploy
     if: branch = master AND tag IS present
@@ -25,7 +25,7 @@ script:
 jobs:
   include:
     - stage: lint
-      script: black --check apiron tests
+      script: black --check -t py34 apiron tests
 
     - stage: deploy
       before_deploy:
@@ -43,7 +43,6 @@ jobs:
             repo: ithaka/apiron
             branch: master
             tags: true
-            python: '3.4'
 
         - &pypi
           provider: pypi
@@ -56,7 +55,6 @@ jobs:
             repo: ithaka/apiron
             branch: master
             tags: true
-            python: '3.4'
 
         - <<: *pypi
           server: 'https://test.pypi.org/legacy/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,19 @@ python:
   - '3.5'
   - '3.4'
 
+# The "install" and "script" here are the default stage (test).
 install:
   - pip install -r dev-requirements.txt
 
+script:
+  - pytest
+
+# The stages will run in the order they appear here.
 stages:
-  - name: lint
+  - lint
   - test
   - name: deploy
     if: branch = master AND tag IS present
-
-script:
-  - pytest
 
 jobs:
   include:
@@ -34,7 +36,7 @@ jobs:
       before_deploy:
         python setup.py sdist bdist_wheel
       deploy:
-        - provider: releases
+        - provider: releases  # GitHub releases
           api_key:
             secure: 'AEjhjd5YuhY1wfGEsjd1RELByc7XPKsuyQ+0HBm9vvowQEvfeVIzrJ5/C4rSS5GSYMqv2oFLhU8bssVz/p6XqXqnM73ZoAJe8bIxvYDXdeKMHLSg3HUltbfb4+4VDbgS0/gCs8K4WpAlcAChs3OXoS2ALb9g7R2HkX0rbBqqQczJBi6Gfj6NxpXr7HtRWUnJ08+RBtG8wtjrgY5WQsZuXzlmpyJV0f4/LpRNOiYxnUhyWJQf0gpuvQG/snqoFoT39Sz69HGHls5qYk4QO+I1Kpsy/a0A7vHWZE6jCj+HnCzKFSvgBk/nAQP19Yat6/4ZcooRLtLW81rW2L04OvSE/rWwC+6rrtzNX3eOilbG/Ctwsw1RhQugcIfgKcfMJed+0GpWvtUn5rGNSgx9/xKE9n6oX2l2hVa1rhxAYOYw7RP+bSTmGwL/Cld10bVKOrhIiuMnVUIy/7KlHyfo5Yz84HckZnXGpStKnz5apkx5076axO85vf6R+V6un+Wkwn2ABUB8QvNWObPfLZBb1/a83+pD3FOMAWlKfwC0JzTwzhLhlJ8s2RKwotJP+Fm3/h6Hr6ren6da88v56c4R3gjS4r1RsQPcEQ1MA1Nw74m8fC1ciTG5BLCWeQov6q4H6C6OVmAc14FQe/oNxVyJmKNcllFkpz4dMTkW05PjrwRvqN0='
           file_glob: true
@@ -47,7 +49,7 @@ jobs:
             branch: master
             tags: true
 
-        - &pypi
+        - &pypi  # Production PyPI
           provider: pypi
           user: apiron
           password:
@@ -59,5 +61,5 @@ jobs:
             branch: master
             tags: true
 
-        - <<: *pypi
+        - <<: *pypi  # Test PyPI
           server: 'https://test.pypi.org/legacy/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ script:
 jobs:
   include:
     - stage: lint
+      install:
+        - pip install -r dev-requirements.txt
+        - pip install black
       script: black --check -t py34 apiron tests
 
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,62 @@
 dist: xenial
 language: python
 cache: pip
+notifications:
+  email: false
+
 python:
   - '3.4'
   - '3.5'
   - '3.6'
   - '3.7'
-script:
-  - pytest
+
 install:
   - pip install -r dev-requirements.txt
-notifications:
-  email: false
-before_deploy:
-  python setup.py sdist bdist_wheel
-deploy:
-  - provider: releases
-    api_key:
-      secure: 'AEjhjd5YuhY1wfGEsjd1RELByc7XPKsuyQ+0HBm9vvowQEvfeVIzrJ5/C4rSS5GSYMqv2oFLhU8bssVz/p6XqXqnM73ZoAJe8bIxvYDXdeKMHLSg3HUltbfb4+4VDbgS0/gCs8K4WpAlcAChs3OXoS2ALb9g7R2HkX0rbBqqQczJBi6Gfj6NxpXr7HtRWUnJ08+RBtG8wtjrgY5WQsZuXzlmpyJV0f4/LpRNOiYxnUhyWJQf0gpuvQG/snqoFoT39Sz69HGHls5qYk4QO+I1Kpsy/a0A7vHWZE6jCj+HnCzKFSvgBk/nAQP19Yat6/4ZcooRLtLW81rW2L04OvSE/rWwC+6rrtzNX3eOilbG/Ctwsw1RhQugcIfgKcfMJed+0GpWvtUn5rGNSgx9/xKE9n6oX2l2hVa1rhxAYOYw7RP+bSTmGwL/Cld10bVKOrhIiuMnVUIy/7KlHyfo5Yz84HckZnXGpStKnz5apkx5076axO85vf6R+V6un+Wkwn2ABUB8QvNWObPfLZBb1/a83+pD3FOMAWlKfwC0JzTwzhLhlJ8s2RKwotJP+Fm3/h6Hr6ren6da88v56c4R3gjS4r1RsQPcEQ1MA1Nw74m8fC1ciTG5BLCWeQov6q4H6C6OVmAc14FQe/oNxVyJmKNcllFkpz4dMTkW05PjrwRvqN0='
-    file_glob: true
-    file:
-      - dist/apiron-*-py3-none-any.whl
-      - dist/apiron-*.tar.gz
-    skip_cleanup: true
-    on:
-      repo: ithaka/apiron
-      branch: master
-      tags: true
-      python: '3.4'
-  - provider: pypi
-    server: 'https://test.pypi.org/legacy/'
-    user: apiron
-    password:
-      secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
-    skip_cleanup: true
-    skip_existing: true
-    on:
-      repo: ithaka/apiron
-      branch: master
-      tags: true
-      python: '3.4'
-  - provider: pypi
-    user: apiron
-    password:
-      secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
-    skip_cleanup: true
-    skip_existing: true
-    on:
-      repo: ithaka/apiron
-      branch: master
-      tags: true
-      python: '3.4'
+
+stages:
+  - lint
+  - test
+  - name: deploy
+    if: branch = master AND tag IS present
+
+script:
+  - pytest
+
+jobs:
+  include:
+    - stage: lint
+      script: black --check apiron tests
+
+    - stage: deploy
+      before_deploy:
+        python setup.py sdist bdist_wheel
+      deploy:
+        - provider: releases
+          api_key:
+            secure: 'AEjhjd5YuhY1wfGEsjd1RELByc7XPKsuyQ+0HBm9vvowQEvfeVIzrJ5/C4rSS5GSYMqv2oFLhU8bssVz/p6XqXqnM73ZoAJe8bIxvYDXdeKMHLSg3HUltbfb4+4VDbgS0/gCs8K4WpAlcAChs3OXoS2ALb9g7R2HkX0rbBqqQczJBi6Gfj6NxpXr7HtRWUnJ08+RBtG8wtjrgY5WQsZuXzlmpyJV0f4/LpRNOiYxnUhyWJQf0gpuvQG/snqoFoT39Sz69HGHls5qYk4QO+I1Kpsy/a0A7vHWZE6jCj+HnCzKFSvgBk/nAQP19Yat6/4ZcooRLtLW81rW2L04OvSE/rWwC+6rrtzNX3eOilbG/Ctwsw1RhQugcIfgKcfMJed+0GpWvtUn5rGNSgx9/xKE9n6oX2l2hVa1rhxAYOYw7RP+bSTmGwL/Cld10bVKOrhIiuMnVUIy/7KlHyfo5Yz84HckZnXGpStKnz5apkx5076axO85vf6R+V6un+Wkwn2ABUB8QvNWObPfLZBb1/a83+pD3FOMAWlKfwC0JzTwzhLhlJ8s2RKwotJP+Fm3/h6Hr6ren6da88v56c4R3gjS4r1RsQPcEQ1MA1Nw74m8fC1ciTG5BLCWeQov6q4H6C6OVmAc14FQe/oNxVyJmKNcllFkpz4dMTkW05PjrwRvqN0='
+          file_glob: true
+          file:
+            - dist/apiron-*-py3-none-any.whl
+            - dist/apiron-*.tar.gz
+          skip_cleanup: true
+          on:
+            repo: ithaka/apiron
+            branch: master
+            tags: true
+            python: '3.4'
+
+        - &pypi
+          provider: pypi
+          user: apiron
+          password:
+            secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
+          skip_cleanup: true
+          skip_existing: true
+          on:
+            repo: ithaka/apiron
+            branch: master
+            tags: true
+            python: '3.4'
+
+        - <<: *pypi
+          server: 'https://test.pypi.org/legacy/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - pip install black pyflakes
       script:
         - pyflakes apiron tests
-        - black --check -t py34 apiron tests
+        - black --check apiron tests
 
     - stage: deploy
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,10 @@ jobs:
     - stage: lint
       install:
         - pip install -r dev-requirements.txt
-        - pip install black
-      script: black --check -t py34 apiron tests
+        - pip install black pyflakes
+      script:
+        - pyflakes apiron tests
+        - black --check -t py34 apiron tests
 
     - stage: deploy
       before_deploy:

--- a/apiron/__init__.py
+++ b/apiron/__init__.py
@@ -1,20 +1,11 @@
 from apiron.client import ServiceCaller, Timeout
-from apiron.endpoint import (
-    Endpoint,
-    JsonEndpoint,
-    StreamingEndpoint,
-    StubEndpoint,
-)
+from apiron.endpoint import Endpoint, JsonEndpoint, StreamingEndpoint, StubEndpoint
 from apiron.exceptions import (
     APIException,
     NoHostsAvailableException,
     UnfulfilledParameterException,
 )
-from apiron.service import (
-    DiscoverableService,
-    Service,
-    ServiceBase,
-)
+from apiron.service import DiscoverableService, Service, ServiceBase
 
 __all__ = [
     "APIException",

--- a/apiron/__init__.py
+++ b/apiron/__init__.py
@@ -1,10 +1,6 @@
 from apiron.client import ServiceCaller, Timeout
 from apiron.endpoint import Endpoint, JsonEndpoint, StreamingEndpoint, StubEndpoint
-from apiron.exceptions import (
-    APIException,
-    NoHostsAvailableException,
-    UnfulfilledParameterException,
-)
+from apiron.exceptions import APIException, NoHostsAvailableException, UnfulfilledParameterException
 from apiron.service import DiscoverableService, Service, ServiceBase
 
 __all__ = [

--- a/apiron/__init__.py
+++ b/apiron/__init__.py
@@ -1,4 +1,8 @@
 from apiron.endpoint import *
 from apiron.service import *
 from apiron.client import ServiceCaller, Timeout
-from apiron.exceptions import APIException, NoHostsAvailableException, UnfulfilledParameterException
+from apiron.exceptions import (
+    APIException,
+    NoHostsAvailableException,
+    UnfulfilledParameterException,
+)

--- a/apiron/__init__.py
+++ b/apiron/__init__.py
@@ -1,8 +1,32 @@
-from apiron.endpoint import *
-from apiron.service import *
 from apiron.client import ServiceCaller, Timeout
+from apiron.endpoint import (
+    Endpoint,
+    JsonEndpoint,
+    StreamingEndpoint,
+    StubEndpoint,
+)
 from apiron.exceptions import (
     APIException,
     NoHostsAvailableException,
     UnfulfilledParameterException,
 )
+from apiron.service import (
+    DiscoverableService,
+    Service,
+    ServiceBase,
+)
+
+__all__ = [
+    "APIException",
+    "DiscoverableService",
+    "Endpoint",
+    "JsonEndpoint",
+    "NoHostsAvailableException",
+    "Service",
+    "ServiceBase",
+    "ServiceCaller",
+    "StreamingEndpoint",
+    "StubEndpoint",
+    "Timeout",
+    "UnfulfilledParameterException",
+]

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -22,9 +22,7 @@ DEFAULT_STATUS_CODES_TO_RETRY_ON = range(500, 600)
 
 Timeout = collections.namedtuple("Timeout", ["connection_timeout", "read_timeout"])
 
-DEFAULT_TIMEOUT = Timeout(
-    connection_timeout=DEFAULT_CONNECTION_TIMEOUT, read_timeout=DEFAULT_READ_TIMEOUT
-)
+DEFAULT_TIMEOUT = Timeout(connection_timeout=DEFAULT_CONNECTION_TIMEOUT, read_timeout=DEFAULT_READ_TIMEOUT)
 DEFAULT_RETRY = retry.Retry(
     total=DEFAULT_TOTAL_RETRIES,
     connect=DEFAULT_CONNECTION_RETRIES,
@@ -227,11 +225,7 @@ class ServiceCaller:
         logger = logger or LOGGER
 
         if hasattr(endpoint, "stub_response"):
-            logger.info(
-                "Stub call for endpoint defined by {}".format(
-                    getattr(endpoint, "endpoint_params", {})
-                )
-            )
+            logger.info("Stub call for endpoint defined by {}".format(getattr(endpoint, "endpoint_params", {})))
             if callable(endpoint.stub_response):
                 return endpoint.stub_response(
                     method=method or getattr(endpoint, "default_method", "GET"),
@@ -249,9 +243,7 @@ class ServiceCaller:
         managing_session = False
 
         if not session:
-            session = cls.get_adapted_session(
-                adapters.HTTPAdapter(max_retries=retry_spec)
-            )
+            session = cls.get_adapted_session(adapters.HTTPAdapter(max_retries=retry_spec))
             managing_session = True
 
         request = cls.build_request_object(
@@ -269,11 +261,7 @@ class ServiceCaller:
             **kwargs
         )
 
-        logger.info(
-            "{method} {url}".format(
-                method=method or endpoint.default_method, url=request.url
-            )
-        )
+        logger.info("{method} {url}".format(method=method or endpoint.default_method, url=request.url))
 
         response = session.send(
             request,
@@ -285,9 +273,7 @@ class ServiceCaller:
             "{status} {url}{history}".format(
                 status=response.status_code,
                 url=response.url,
-                history=" ({} redirect(s))".format(len(response.history))
-                if response.history
-                else "",
+                history=" ({} redirect(s))".format(len(response.history)) if response.history else "",
             )
         )
 

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -20,9 +20,11 @@ DEFAULT_READ_RETRIES = 1
 DEFAULT_TOTAL_RETRIES = 1
 DEFAULT_STATUS_CODES_TO_RETRY_ON = range(500, 600)
 
-Timeout = collections.namedtuple('Timeout', ['connection_timeout', 'read_timeout'])
+Timeout = collections.namedtuple("Timeout", ["connection_timeout", "read_timeout"])
 
-DEFAULT_TIMEOUT = Timeout(connection_timeout=DEFAULT_CONNECTION_TIMEOUT, read_timeout=DEFAULT_READ_TIMEOUT)
+DEFAULT_TIMEOUT = Timeout(
+    connection_timeout=DEFAULT_CONNECTION_TIMEOUT, read_timeout=DEFAULT_READ_TIMEOUT
+)
 DEFAULT_RETRY = retry.Retry(
     total=DEFAULT_TOTAL_RETRIES,
     connect=DEFAULT_CONNECTION_RETRIES,
@@ -52,8 +54,8 @@ class ServiceCaller:
         :rtype:
             str
         """
-        host += '/' if not host.endswith('/') else ''
-        path = path.lstrip('/')
+        host += "/" if not host.endswith("/") else ""
+        path = path.lstrip("/")
 
         return parse.urljoin(host, path)
 
@@ -68,8 +70,8 @@ class ServiceCaller:
             The adapted :class:`requests.Session` instance
         """
         session = requests.Session()
-        session.mount('http://', adapter)
-        session.mount('https://', adapter)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
         return session
 
     @staticmethod
@@ -116,10 +118,10 @@ class ServiceCaller:
 
         if path_kwargs:
             warnings.warn(
-                'path_kwargs is no longer necessary and will be removed in a future version of apiron. '
-                'You can call endpoints using plain keyword arguments instead!',
+                "path_kwargs is no longer necessary and will be removed in a future version of apiron. "
+                "You can call endpoints using plain keyword arguments instead!",
                 RuntimeWarning,
-                stacklevel=4
+                stacklevel=4,
             )
 
         path_kwargs = path_kwargs or {}
@@ -224,14 +226,15 @@ class ServiceCaller:
         """
         logger = logger or LOGGER
 
-        if hasattr(endpoint, 'stub_response'):
+        if hasattr(endpoint, "stub_response"):
             logger.info(
-                'Stub call for endpoint defined by {}'
-                .format(getattr(endpoint, 'endpoint_params', {}))
+                "Stub call for endpoint defined by {}".format(
+                    getattr(endpoint, "endpoint_params", {})
+                )
             )
             if callable(endpoint.stub_response):
                 return endpoint.stub_response(
-                    method=method or getattr(endpoint, 'default_method', 'GET'),
+                    method=method or getattr(endpoint, "default_method", "GET"),
                     path_kwargs=path_kwargs,
                     params=params,
                     data=data,
@@ -246,7 +249,9 @@ class ServiceCaller:
         managing_session = False
 
         if not session:
-            session = cls.get_adapted_session(adapters.HTTPAdapter(max_retries=retry_spec))
+            session = cls.get_adapted_session(
+                adapters.HTTPAdapter(max_retries=retry_spec)
+            )
             managing_session = True
 
         request = cls.build_request_object(
@@ -264,22 +269,27 @@ class ServiceCaller:
             **kwargs
         )
 
-        logger.info('{method} {url}'.format(
-            method=method or endpoint.default_method,
-            url=request.url,
-        ))
+        logger.info(
+            "{method} {url}".format(
+                method=method or endpoint.default_method, url=request.url
+            )
+        )
 
         response = session.send(
             request,
             timeout=(timeout_spec.connection_timeout, timeout_spec.read_timeout),
-            stream=getattr(endpoint, 'streaming', False),
+            stream=getattr(endpoint, "streaming", False),
         )
 
-        logger.info('{status} {url}{history}'.format(
-            status=response.status_code,
-            url=response.url,
-            history=' ({} redirect(s))'.format(len(response.history)) if response.history else '',
-        ))
+        logger.info(
+            "{status} {url}{history}".format(
+                status=response.status_code,
+                url=response.url,
+                history=" ({} redirect(s))".format(len(response.history))
+                if response.history
+                else "",
+            )
+        )
 
         if managing_session:
             session.close()

--- a/apiron/endpoint/__init__.py
+++ b/apiron/endpoint/__init__.py
@@ -4,9 +4,4 @@ from apiron.endpoint.streaming import StreamingEndpoint
 from apiron.endpoint.stub import StubEndpoint
 
 
-__all__ = [
-    'Endpoint',
-    'JsonEndpoint',
-    'StreamingEndpoint',
-    'StubEndpoint',
-]
+__all__ = ["Endpoint", "JsonEndpoint", "StreamingEndpoint", "StubEndpoint"]

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -19,12 +19,16 @@ class Endpoint:
         The callable attribute is set dynamically by the :class:`Service` subclass this endpoint is a part of.
         Arguments are identical to those of :func:`apiron.client.ServiceCaller.call`
         """
-        if hasattr(self, 'callable'):
+        if hasattr(self, "callable"):
             return self.callable(*args, **kwargs)
         else:
-            raise TypeError('Endpoints are only callable in conjunction with a Service class.')
+            raise TypeError(
+                "Endpoints are only callable in conjunction with a Service class."
+            )
 
-    def __init__(self, path='/', default_method='GET', default_params=None, required_params=None):
+    def __init__(
+        self, path="/", default_method="GET", default_params=None, required_params=None
+    ):
         """
         :param str path:
             The URL path for this endpoint, without the protocol or domain
@@ -40,11 +44,13 @@ class Endpoint:
         """
         self.default_method = default_method
 
-        if '?' in path:
+        if "?" in path:
             warnings.warn(
-                'Endpoint path may contain query parameters. '
-                'Use the default_params or required_params attributes in the initialization of this endpoint, '
-                'or the params argument when calling the endpoint instead.'.format(path),
+                "Endpoint path may contain query parameters. "
+                "Use the default_params or required_params attributes in the initialization of this endpoint, "
+                "or the params argument when calling the endpoint instead.".format(
+                    path
+                ),
                 stacklevel=3,
             )
 
@@ -112,8 +118,8 @@ class Endpoint:
     def _validate_path_placeholders(self, placeholder_names, path_kwargs):
         if any(path_kwarg not in placeholder_names for path_kwarg in path_kwargs):
             warnings.warn(
-                'An unknown path kwarg was supplied to {}. '
-                'kwargs supplied: {}'.format(self, path_kwargs),
+                "An unknown path kwarg was supplied to {}. "
+                "kwargs supplied: {}".format(self, path_kwargs),
                 RuntimeWarning,
                 stacklevel=6,
             )
@@ -137,14 +143,13 @@ class Endpoint:
         empty_params = {
             param: supplied_params[param]
             for param in supplied_params
-            if supplied_params[param] in (None, '')
+            if supplied_params[param] in (None, "")
         }
         if empty_params:
             warnings.warn(
-                'The {path} endpoint '
-                'was called with empty parameters: {empty_params}'.format(
-                    path=self.path,
-                    empty_params=empty_params,
+                "The {path} endpoint "
+                "was called with empty parameters: {empty_params}".format(
+                    path=self.path, empty_params=empty_params
                 ),
                 RuntimeWarning,
                 stacklevel=5,
@@ -153,15 +158,11 @@ class Endpoint:
         unfulfilled_params = {
             param
             for param in self.required_params
-            if param not in supplied_params
-            and param not in self.default_params
+            if param not in supplied_params and param not in self.default_params
         }
 
         if unfulfilled_params:
-            raise UnfulfilledParameterException(
-                self.path,
-                unfulfilled_params,
-            )
+            raise UnfulfilledParameterException(self.path, unfulfilled_params)
 
         merged_params = self.default_params.copy()
         merged_params.update(supplied_params)

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -22,13 +22,9 @@ class Endpoint:
         if hasattr(self, "callable"):
             return self.callable(*args, **kwargs)
         else:
-            raise TypeError(
-                "Endpoints are only callable in conjunction with a Service class."
-            )
+            raise TypeError("Endpoints are only callable in conjunction with a Service class.")
 
-    def __init__(
-        self, path="/", default_method="GET", default_params=None, required_params=None
-    ):
+    def __init__(self, path="/", default_method="GET", default_params=None, required_params=None):
         """
         :param str path:
             The URL path for this endpoint, without the protocol or domain
@@ -48,9 +44,7 @@ class Endpoint:
             warnings.warn(
                 "Endpoint path may contain query parameters. "
                 "Use the default_params or required_params attributes in the initialization of this endpoint, "
-                "or the params argument when calling the endpoint instead.".format(
-                    path
-                ),
+                "or the params argument when calling the endpoint instead.".format(path),
                 stacklevel=3,
             )
 
@@ -109,17 +103,12 @@ class Endpoint:
         """
 
         parser = string.Formatter()
-        return [
-            placeholder_name
-            for _, placeholder_name, _, _ in parser.parse(self.path)
-            if placeholder_name
-        ]
+        return [placeholder_name for _, placeholder_name, _, _ in parser.parse(self.path) if placeholder_name]
 
     def _validate_path_placeholders(self, placeholder_names, path_kwargs):
         if any(path_kwarg not in placeholder_names for path_kwarg in path_kwargs):
             warnings.warn(
-                "An unknown path kwarg was supplied to {}. "
-                "kwargs supplied: {}".format(self, path_kwargs),
+                "An unknown path kwarg was supplied to {}. kwargs supplied: {}".format(self, path_kwargs),
                 RuntimeWarning,
                 stacklevel=6,
             )
@@ -141,24 +130,18 @@ class Endpoint:
         supplied_params = supplied_params or {}
 
         empty_params = {
-            param: supplied_params[param]
-            for param in supplied_params
-            if supplied_params[param] in (None, "")
+            param: supplied_params[param] for param in supplied_params if supplied_params[param] in (None, "")
         }
         if empty_params:
             warnings.warn(
                 "The {path} endpoint "
-                "was called with empty parameters: {empty_params}".format(
-                    path=self.path, empty_params=empty_params
-                ),
+                "was called with empty parameters: {empty_params}".format(path=self.path, empty_params=empty_params),
                 RuntimeWarning,
                 stacklevel=5,
             )
 
         unfulfilled_params = {
-            param
-            for param in self.required_params
-            if param not in supplied_params and param not in self.default_params
+            param for param in self.required_params if param not in supplied_params and param not in self.default_params
         }
 
         if unfulfilled_params:

--- a/apiron/endpoint/json.py
+++ b/apiron/endpoint/json.py
@@ -7,8 +7,21 @@ class JsonEndpoint(Endpoint):
     An endpoint that returns :mimetype:`application/json`
     """
 
-    def __init__(self, *args, path='/', default_method='GET', default_params=None, required_params=None, preserve_order=False):
-        super().__init__(path=path, default_method=default_method, default_params=default_params, required_params=required_params)
+    def __init__(
+        self,
+        *args,
+        path="/",
+        default_method="GET",
+        default_params=None,
+        required_params=None,
+        preserve_order=False
+    ):
+        super().__init__(
+            path=path,
+            default_method=default_method,
+            default_params=default_params,
+            required_params=required_params,
+        )
         self.preserve_order = preserve_order
 
     def format_response(self, response):
@@ -25,8 +38,10 @@ class JsonEndpoint(Endpoint):
             :class:`collections.OrderedDict` if ``preserve_order`` is ``True``
         """
 
-        return response.json(object_pairs_hook=collections.OrderedDict if self.preserve_order else None)
+        return response.json(
+            object_pairs_hook=collections.OrderedDict if self.preserve_order else None
+        )
 
     @property
     def required_headers(self):
-        return {'Accept': 'application/json'}
+        return {"Accept": "application/json"}

--- a/apiron/endpoint/json.py
+++ b/apiron/endpoint/json.py
@@ -8,19 +8,10 @@ class JsonEndpoint(Endpoint):
     """
 
     def __init__(
-        self,
-        *args,
-        path="/",
-        default_method="GET",
-        default_params=None,
-        required_params=None,
-        preserve_order=False
+        self, *args, path="/", default_method="GET", default_params=None, required_params=None, preserve_order=False
     ):
         super().__init__(
-            path=path,
-            default_method=default_method,
-            default_params=default_params,
-            required_params=required_params,
+            path=path, default_method=default_method, default_params=default_params, required_params=required_params
         )
         self.preserve_order = preserve_order
 
@@ -38,9 +29,7 @@ class JsonEndpoint(Endpoint):
             :class:`collections.OrderedDict` if ``preserve_order`` is ``True``
         """
 
-        return response.json(
-            object_pairs_hook=collections.OrderedDict if self.preserve_order else None
-        )
+        return response.json(object_pairs_hook=collections.OrderedDict if self.preserve_order else None)
 
     @property
     def required_headers(self):

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -15,9 +15,7 @@ class StubEndpoint:
         if hasattr(self, "callable"):
             return self.callable(*args, **kwargs)
         else:
-            raise TypeError(
-                "Endpoints are only callable in conjunction with a Service class."
-            )
+            raise TypeError("Endpoints are only callable in conjunction with a Service class.")
 
     def __init__(self, stub_response=None, **kwargs):
         """

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -12,10 +12,12 @@ class StubEndpoint:
         The callable attribute is set dynamically by the :class:`Service` subclass this endpoint is a part of.
         Arguments are identical to those of :func:`apiron.client.ServiceCaller.call`
         """
-        if hasattr(self, 'callable'):
+        if hasattr(self, "callable"):
             return self.callable(*args, **kwargs)
         else:
-            raise TypeError('Endpoints are only callable in conjunction with a Service class.')
+            raise TypeError(
+                "Endpoints are only callable in conjunction with a Service class."
+            )
 
     def __init__(self, stub_response=None, **kwargs):
         """
@@ -37,4 +39,4 @@ class StubEndpoint:
             These don't do anything for the stub but streamline the interface.
         """
         self.endpoint_params = kwargs or {}
-        self.stub_response = stub_response or 'stub for {}'.format(self.endpoint_params)
+        self.stub_response = stub_response or "stub for {}".format(self.endpoint_params)

--- a/apiron/exceptions.py
+++ b/apiron/exceptions.py
@@ -4,17 +4,18 @@ class APIException(Exception):
 
 class NoHostsAvailableException(APIException):
     def __init__(self, service_name):
-        message = 'No hosts available for service: {service_name}'.format(service_name=service_name)
+        message = "No hosts available for service: {service_name}".format(
+            service_name=service_name
+        )
         super().__init__(message)
 
 
 class UnfulfilledParameterException(APIException):
     def __init__(self, endpoint_path, unfulfilled_params):
         message = (
-            'The {endpoint_path} endpoint '
-            'was called without required parameters: {unfulfilled_params}'.format(
-                endpoint_path=endpoint_path,
-                unfulfilled_params=unfulfilled_params,
+            "The {endpoint_path} endpoint "
+            "was called without required parameters: {unfulfilled_params}".format(
+                endpoint_path=endpoint_path, unfulfilled_params=unfulfilled_params
             )
         )
         super().__init__(message)

--- a/apiron/exceptions.py
+++ b/apiron/exceptions.py
@@ -4,18 +4,13 @@ class APIException(Exception):
 
 class NoHostsAvailableException(APIException):
     def __init__(self, service_name):
-        message = "No hosts available for service: {service_name}".format(
-            service_name=service_name
-        )
+        message = "No hosts available for service: {service_name}".format(service_name=service_name)
         super().__init__(message)
 
 
 class UnfulfilledParameterException(APIException):
     def __init__(self, endpoint_path, unfulfilled_params):
-        message = (
-            "The {endpoint_path} endpoint "
-            "was called without required parameters: {unfulfilled_params}".format(
-                endpoint_path=endpoint_path, unfulfilled_params=unfulfilled_params
-            )
+        message = "The {endpoint_path} endpoint was called without required parameters: {unfulfilled_params}".format(
+            endpoint_path=endpoint_path, unfulfilled_params=unfulfilled_params
         )
         super().__init__(message)

--- a/apiron/service/__init__.py
+++ b/apiron/service/__init__.py
@@ -2,8 +2,4 @@ from apiron.service.base import Service, ServiceBase
 from apiron.service.discoverable import DiscoverableService
 
 
-__all__ = [
-    'Service',
-    'ServiceBase',
-    'DiscoverableService',
-]
+__all__ = ["Service", "ServiceBase", "DiscoverableService"]

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -63,4 +63,6 @@ class Service(ServiceBase):
         return self.__class__.domain
 
     def __repr__(self):
-        return '{klass}(domain={domain})'.format(klass=self.__class__.__name__, domain=self.__class__.domain)
+        return "{klass}(domain={domain})".format(
+            klass=self.__class__.__name__, domain=self.__class__.domain
+        )

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -63,6 +63,4 @@ class Service(ServiceBase):
         return self.__class__.domain
 
     def __repr__(self):
-        return "{klass}(domain={domain})".format(
-            klass=self.__class__.__name__, domain=self.__class__.domain
-        )
+        return "{klass}(domain={domain})".format(klass=self.__class__.__name__, domain=self.__class__.domain)

--- a/apiron/service/discoverable.py
+++ b/apiron/service/discoverable.py
@@ -19,7 +19,5 @@ class DiscoverableService(ServiceBase):
     def __repr__(self):
         klass = self.__class__
         return "{klass}(service_name={service_name}, host_resolver={host_resolver})".format(
-            klass=klass.__name__,
-            service_name=klass.service_name,
-            host_resolver=klass.host_resolver_class.__name__,
+            klass=klass.__name__, service_name=klass.service_name, host_resolver=klass.host_resolver_class.__name__
         )

--- a/apiron/service/discoverable.py
+++ b/apiron/service/discoverable.py
@@ -18,7 +18,7 @@ class DiscoverableService(ServiceBase):
 
     def __repr__(self):
         klass = self.__class__
-        return '{klass}(service_name={service_name}, host_resolver={host_resolver})'.format(
+        return "{klass}(service_name={service_name}, host_resolver={host_resolver})".format(
             klass=klass.__name__,
             service_name=klass.service_name,
             host_resolver=klass.host_resolver_class.__name__,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+black==19.3b0
 pytest==4.2.0
 pytest-cov==2.6.1
 sphinx==1.7.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 
-black==19.3b0
 pytest==4.2.0
 pytest-cov==2.6.1
 sphinx==1.7.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target-version = ['py34', 'py35', 'py36', 'py37', 'py38']

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -3,11 +3,13 @@ import pytest
 from apiron import Service, ServiceBase
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def service():
     class SomeService(Service):
-        domain = 'http://foo.com'
+        domain = "http://foo.com"
+
     return SomeService
+
 
 class TestServiceBase:
     def test_get_hosts_returns_empty_list_by_default(self):
@@ -19,19 +21,19 @@ class TestServiceBase:
 
 class TestService:
     def test_get_hosts_returns_domain(self, service):
-        assert ['http://foo.com'] == service.get_hosts()
+        assert ["http://foo.com"] == service.get_hosts()
 
     def test_str_method_on_class(self, service):
-        assert 'http://foo.com' == str(service)
+        assert "http://foo.com" == str(service)
 
     def test_str_method_on_instance(self, service):
-        assert 'http://foo.com' == str(service())
+        assert "http://foo.com" == str(service())
 
     def test_repr_method_on_class(self, service):
-        assert 'SomeService(domain=http://foo.com)' == repr(service)
+        assert "SomeService(domain=http://foo.com)" == repr(service)
 
     def test_repr_method_on_instance(self, service):
-        assert 'SomeService(domain=http://foo.com)' == repr(service())
+        assert "SomeService(domain=http://foo.com)" == repr(service())
 
     def test_required_headers_returns_empty_dict_by_default(self, service):
         assert {} == service.required_headers

--- a/tests/service/test_discoverable.py
+++ b/tests/service/test_discoverable.py
@@ -6,31 +6,37 @@ from apiron import DiscoverableService
 class FakeResolver:
     @staticmethod
     def resolve(service_name):
-        return ['fake']
+        return ["fake"]
 
 
 class FakeService(DiscoverableService):
-    service_name = 'fake-service'
+    service_name = "fake-service"
     host_resolver_class = FakeResolver
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def service():
     return FakeService
 
 
 class TestDiscoverableService:
     def test_get_hosts_returns_hosts_from_resolver(self, service):
-        assert ['fake'] == service.get_hosts()
+        assert ["fake"] == service.get_hosts()
 
     def test_str_method_on_class(self, service):
-        assert 'fake-service' == str(service)
+        assert "fake-service" == str(service)
 
     def test_str_method_on_instance(self, service):
-        assert 'fake-service' == str(service())
+        assert "fake-service" == str(service())
 
     def test_repr_method_on_class(self, service):
-        assert 'FakeService(service_name=fake-service, host_resolver=FakeResolver)' == repr(service)
+        assert (
+            "FakeService(service_name=fake-service, host_resolver=FakeResolver)"
+            == repr(service)
+        )
 
     def test_repr_method_on_instance(self, service):
-        assert 'FakeService(service_name=fake-service, host_resolver=FakeResolver)' == repr(service())
+        assert (
+            "FakeService(service_name=fake-service, host_resolver=FakeResolver)"
+            == repr(service())
+        )

--- a/tests/service/test_discoverable.py
+++ b/tests/service/test_discoverable.py
@@ -30,13 +30,7 @@ class TestDiscoverableService:
         assert "fake-service" == str(service())
 
     def test_repr_method_on_class(self, service):
-        assert (
-            "FakeService(service_name=fake-service, host_resolver=FakeResolver)"
-            == repr(service)
-        )
+        assert "FakeService(service_name=fake-service, host_resolver=FakeResolver)" == repr(service)
 
     def test_repr_method_on_instance(self, service):
-        assert (
-            "FakeService(service_name=fake-service, host_resolver=FakeResolver)"
-            == repr(service())
-        )
+        assert "FakeService(service_name=fake-service, host_resolver=FakeResolver)" == repr(service())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,56 +6,54 @@ from apiron import ServiceCaller, NoHostsAvailableException
 
 
 class TestClient:
-    @mock.patch('requests.sessions.Session', autospec=True)
+    @mock.patch("requests.sessions.Session", autospec=True)
     def test_get_adapted_session(self, mock_session):
         adapter = mock.Mock()
         adapted_session = ServiceCaller.get_adapted_session(adapter)
-        assert adapter == adapted_session.get_adapter('http://foo.com')
-        assert adapter == adapted_session.get_adapter('https://foo.com')
+        assert adapter == adapted_session.get_adapter("http://foo.com")
+        assert adapter == adapted_session.get_adapter("https://foo.com")
 
     def test_get_required_headers(self):
         service = mock.Mock()
-        service.required_headers = {'one': 'two'}
+        service.required_headers = {"one": "two"}
         endpoint = mock.Mock()
-        endpoint.required_headers = {'foo': 'bar'}
+        endpoint.required_headers = {"foo": "bar"}
         expected_headers = {}
         expected_headers.update(service.required_headers)
         expected_headers.update(endpoint.required_headers)
         assert expected_headers == ServiceCaller.get_required_headers(service, endpoint)
 
-    @mock.patch('apiron.client.requests.Request')
-    @mock.patch('apiron.client.ServiceCaller.get_required_headers')
+    @mock.patch("apiron.client.requests.Request")
+    @mock.patch("apiron.client.ServiceCaller.get_required_headers")
     def test_build_request_object_passes_arguments_to_request_constructor(
-        self,
-        mock_get_required_headers,
-        mock_request_constructor
+        self, mock_get_required_headers, mock_request_constructor
     ):
         session = mock.Mock()
 
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
 
         endpoint = mock.Mock()
-        endpoint.default_method = 'POST'
-        endpoint.get_formatted_path.return_value = '/foo'
-        endpoint.required_headers = {'header': 'value'}
+        endpoint.default_method = "POST"
+        endpoint.get_formatted_path.return_value = "/foo"
+        endpoint.required_headers = {"header": "value"}
         endpoint.default_params = {}
         endpoint.required_params = set()
 
-        params = {'baz': 'qux'}
+        params = {"baz": "qux"}
         endpoint.get_merged_params.return_value = params
-        data = 'I am a data'
-        json = {'raw': 'data'}
-        headers = {'Accept': 'stuff'}
-        cookies = {'chocolate-chip': 'yes'}
+        data = "I am a data"
+        json = {"raw": "data"}
+        headers = {"Accept": "stuff"}
+        cookies = {"chocolate-chip": "yes"}
         auth = mock.Mock()
 
-        mock_get_required_headers.return_value = {'header': 'value'}
+        mock_get_required_headers.return_value = {"header": "value"}
         expected_headers = {}
         expected_headers.update(headers)
         expected_headers.update(endpoint.required_headers)
 
-        with mock.patch.object(session, 'prepare_request') as mock_prepare_request:
+        with mock.patch.object(session, "prepare_request") as mock_prepare_request:
             ServiceCaller.build_request_object(
                 session,
                 service,
@@ -66,11 +64,11 @@ class TestClient:
                 headers=headers,
                 cookies=cookies,
                 auth=auth,
-                foo='bar',
+                foo="bar",
             )
 
             mock_request_constructor.assert_called_once_with(
-                url='http://host1.biz/foo',
+                url="http://host1.biz/foo",
                 method=endpoint.default_method,
                 headers=expected_headers,
                 cookies=cookies,
@@ -82,31 +80,38 @@ class TestClient:
 
             assert 1 == mock_prepare_request.call_count
 
-    @mock.patch('apiron.client.Timeout')
-    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
-    @mock.patch('apiron.client.ServiceCaller.build_request_object')
-    @mock.patch('requests.adapters.HTTPAdapter', autospec=True)
-    @mock.patch('requests.Session', autospec=True)
-    def test_call(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+    @mock.patch("apiron.client.Timeout")
+    @mock.patch("apiron.client.ServiceCaller.get_adapted_session")
+    @mock.patch("apiron.client.ServiceCaller.build_request_object")
+    @mock.patch("requests.adapters.HTTPAdapter", autospec=True)
+    @mock.patch("requests.Session", autospec=True)
+    def test_call(
+        self,
+        MockSession,
+        MockAdapter,
+        mock_build_request_object,
+        mock_get_adapted_session,
+        mock_timeout,
+    ):
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
 
         endpoint = mock.Mock()
-        endpoint.default_method = 'GET'
-        endpoint.get_formatted_path.return_value = '/foo/'
+        endpoint.default_method = "GET"
+        endpoint.get_formatted_path.return_value = "/foo/"
         endpoint.required_headers = {}
         endpoint.streaming = True
         del endpoint.stub_response
 
         request = mock.Mock()
-        request.url = 'http://host1.biz/foo/'
+        request.url = "http://host1.biz/foo/"
         mock_build_request_object.return_value = request
 
         mock_logger = mock.Mock()
 
         mock_response = mock.Mock()
         mock_response.status_code = 200
-        mock_response.url = 'http://host1.biz/foo/'
+        mock_response.url = "http://host1.biz/foo/"
         mock_response.history = []
 
         mock_session = MockSession()
@@ -114,10 +119,7 @@ class TestClient:
         mock_get_adapted_session.return_value = mock_session
 
         ServiceCaller.call(
-            service,
-            endpoint,
-            timeout_spec=mock_timeout,
-            logger=mock_logger,
+            service, endpoint, timeout_spec=mock_timeout, logger=mock_logger
         )
 
         mock_get_adapted_session.assert_called_once_with(MockAdapter())
@@ -127,11 +129,11 @@ class TestClient:
             stream=endpoint.streaming,
         )
 
-        mock_logger.info.assert_any_call('GET http://host1.biz/foo/')
-        mock_logger.info.assert_any_call('200 http://host1.biz/foo/')
+        mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
+        mock_logger.info.assert_any_call("200 http://host1.biz/foo/")
 
-        endpoint.default_method = 'POST'
-        request.method = 'POST'
+        endpoint.default_method = "POST"
+        request.method = "POST"
 
         ServiceCaller.call(
             service,
@@ -147,15 +149,15 @@ class TestClient:
             stream=endpoint.streaming,
         )
 
-        mock_logger.info.assert_any_call('GET http://host1.biz/foo/')
-        mock_logger.info.assert_any_call('200 http://host1.biz/foo/')
+        mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
+        mock_logger.info.assert_any_call("200 http://host1.biz/foo/")
 
-        request.method = 'PUT'
+        request.method = "PUT"
 
         ServiceCaller.call(
             service,
             endpoint,
-            method='PUT',
+            method="PUT",
             session=mock_session,
             timeout_spec=mock_timeout,
             logger=mock_logger,
@@ -167,16 +169,15 @@ class TestClient:
             stream=endpoint.streaming,
         )
 
-
-    @mock.patch('apiron.client.ServiceCaller.get_adapted_session')
+    @mock.patch("apiron.client.ServiceCaller.get_adapted_session")
     def test_call_with_existing_session(self, mock_get_adapted_session):
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
         service.required_headers = {}
 
         endpoint = mock.Mock()
         endpoint.required_headers = {}
-        endpoint.get_formatted_path.return_value = '/foo/'
+        endpoint.get_formatted_path.return_value = "/foo/"
         del endpoint.stub_response
 
         mock_logger = mock.Mock()
@@ -186,24 +187,19 @@ class TestClient:
         session = mock.Mock()
         session.send.return_value = mock_response
 
-        ServiceCaller.call(
-            service,
-            endpoint,
-            session=session,
-            logger=mock_logger,
-        )
+        ServiceCaller.call(service, endpoint, session=session, logger=mock_logger)
 
         assert not mock_get_adapted_session.called
         assert not session.close.called
 
     def test_call_with_explicit_encoding(self):
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
         service.required_headers = {}
 
         endpoint = mock.Mock()
         endpoint.required_headers = {}
-        endpoint.get_formatted_path.return_value = '/foo/'
+        endpoint.get_formatted_path.return_value = "/foo/"
         del endpoint.stub_response
 
         mock_logger = mock.Mock()
@@ -218,10 +214,10 @@ class TestClient:
             endpoint,
             session=session,
             logger=mock_logger,
-            encoding='FAKE-CODEC'
+            encoding="FAKE-CODEC",
         )
 
-        assert 'FAKE-CODEC' == mock_response.encoding
+        assert "FAKE-CODEC" == mock_response.encoding
 
     def test_build_request_object_raises_no_host_exception(self):
         service = mock.Mock()
@@ -231,7 +227,7 @@ class TestClient:
             ServiceCaller.build_request_object(None, service, None)
 
     def test_choose_host(self):
-        hosts = ['foo', 'bar', 'baz']
+        hosts = ["foo", "bar", "baz"]
         service = mock.Mock()
         service.get_hosts.return_value = hosts
         assert ServiceCaller.choose_host(service) in hosts
@@ -243,87 +239,106 @@ class TestClient:
             ServiceCaller.choose_host(service)
 
 
-@mock.patch('apiron.client.Timeout')
-@mock.patch('apiron.client.ServiceCaller.get_adapted_session')
-@mock.patch('apiron.client.ServiceCaller.build_request_object')
-@mock.patch('requests.adapters.HTTPAdapter', autospec=True)
-@mock.patch('requests.Session', autospec=True)
+@mock.patch("apiron.client.Timeout")
+@mock.patch("apiron.client.ServiceCaller.get_adapted_session")
+@mock.patch("apiron.client.ServiceCaller.build_request_object")
+@mock.patch("requests.adapters.HTTPAdapter", autospec=True)
+@mock.patch("requests.Session", autospec=True)
 class TestClientStubCall:
-
-    def test_call_stub(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+    def test_call_stub(
+        self,
+        MockSession,
+        MockAdapter,
+        mock_build_request_object,
+        mock_get_adapted_session,
+        mock_timeout,
+    ):
         """
         Test getting a response for a ``StubEndpoint``
         """
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
 
         stub_endpoint = mock.Mock()
-        stub_endpoint.stub_response = {'stub': 'response'}
+        stub_endpoint.stub_response = {"stub": "response"}
 
         actual_response = ServiceCaller.call(service, stub_endpoint)
 
-        expected_response = {'stub': 'response'}
+        expected_response = {"stub": "response"}
 
         assert expected_response == actual_response
 
-
-    def test_call_stub_dynamic(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+    def test_call_stub_dynamic(
+        self,
+        MockSession,
+        MockAdapter,
+        mock_build_request_object,
+        mock_get_adapted_session,
+        mock_timeout,
+    ):
         """
         Test getting a response for a ``StubEndpoint`` using a dynamic response
         """
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
 
         stub_endpoint = mock.Mock()
+
         def stub_response(**kwargs):
-            return 'stub response'
+            return "stub response"
+
         stub_endpoint.stub_response = stub_response
 
         actual_response = ServiceCaller.call(service, stub_endpoint)
 
-        expected_response = 'stub response'
+        expected_response = "stub response"
 
         assert expected_response == actual_response
 
-
-    def test_call_stub_dynamic_params(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
+    def test_call_stub_dynamic_params(
+        self,
+        MockSession,
+        MockAdapter,
+        mock_build_request_object,
+        mock_get_adapted_session,
+        mock_timeout,
+    ):
         """
         Test getting a response for a ``StubEndpoint`` using a dynamic response with parameters
         """
         service = mock.Mock()
-        service.get_hosts.return_value = ['http://host1.biz']
+        service.get_hosts.return_value = ["http://host1.biz"]
 
         stub_endpoint = mock.Mock()
+
         def stub_response(**kwargs):
-            response_map = {
-                'param_value': 'correct',
-                'default': 'incorrect',
-            }
-            data_key = kwargs['params'].setdefault('param_key', 'default')
+            response_map = {"param_value": "correct", "default": "incorrect"}
+            data_key = kwargs["params"].setdefault("param_key", "default")
             return response_map[data_key]
 
         stub_endpoint.stub_response = stub_response
 
         actual_response = ServiceCaller.call(
-            service,
-            stub_endpoint,
-            params={'param_key': 'param_value'}
+            service, stub_endpoint, params={"param_key": "param_value"}
         )
 
-        expected_response = 'correct'
+        expected_response = "correct"
 
         assert expected_response == actual_response
 
 
-@pytest.mark.parametrize('host,path,url', [
-    ('http://biz.com', '/endpoint', 'http://biz.com/endpoint'),
-    ('http://biz.com/', 'endpoint', 'http://biz.com/endpoint'),
-    ('http://biz.com/', '/endpoint', 'http://biz.com/endpoint'),
-    ('http://biz.com', 'endpoint', 'http://biz.com/endpoint'),
-    ('http://biz.com/v2', '/endpoint', 'http://biz.com/v2/endpoint'),
-    ('http://biz.com/v2/', 'endpoint', 'http://biz.com/v2/endpoint'),
-    ('http://biz.com/v2/', '/endpoint', 'http://biz.com/v2/endpoint'),
-    ('http://biz.com/v2', 'endpoint', 'http://biz.com/v2/endpoint'),
-])
+@pytest.mark.parametrize(
+    "host,path,url",
+    [
+        ("http://biz.com", "/endpoint", "http://biz.com/endpoint"),
+        ("http://biz.com/", "endpoint", "http://biz.com/endpoint"),
+        ("http://biz.com/", "/endpoint", "http://biz.com/endpoint"),
+        ("http://biz.com", "endpoint", "http://biz.com/endpoint"),
+        ("http://biz.com/v2", "/endpoint", "http://biz.com/v2/endpoint"),
+        ("http://biz.com/v2/", "endpoint", "http://biz.com/v2/endpoint"),
+        ("http://biz.com/v2/", "/endpoint", "http://biz.com/v2/endpoint"),
+        ("http://biz.com/v2", "endpoint", "http://biz.com/v2/endpoint"),
+    ],
+)
 def test_build_url(host, path, url):
     assert url == ServiceCaller.build_url(host, path)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,14 +85,7 @@ class TestClient:
     @mock.patch("apiron.client.ServiceCaller.build_request_object")
     @mock.patch("requests.adapters.HTTPAdapter", autospec=True)
     @mock.patch("requests.Session", autospec=True)
-    def test_call(
-        self,
-        MockSession,
-        MockAdapter,
-        mock_build_request_object,
-        mock_get_adapted_session,
-        mock_timeout,
-    ):
+    def test_call(self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout):
         service = mock.Mock()
         service.get_hosts.return_value = ["http://host1.biz"]
 
@@ -118,15 +111,11 @@ class TestClient:
         mock_session.send.return_value = mock_response
         mock_get_adapted_session.return_value = mock_session
 
-        ServiceCaller.call(
-            service, endpoint, timeout_spec=mock_timeout, logger=mock_logger
-        )
+        ServiceCaller.call(service, endpoint, timeout_spec=mock_timeout, logger=mock_logger)
 
         mock_get_adapted_session.assert_called_once_with(MockAdapter())
         mock_session.send.assert_called_once_with(
-            request,
-            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
-            stream=endpoint.streaming,
+            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -135,18 +124,10 @@ class TestClient:
         endpoint.default_method = "POST"
         request.method = "POST"
 
-        ServiceCaller.call(
-            service,
-            endpoint,
-            session=mock_session,
-            timeout_spec=mock_timeout,
-            logger=mock_logger,
-        )
+        ServiceCaller.call(service, endpoint, session=mock_session, timeout_spec=mock_timeout, logger=mock_logger)
 
         mock_session.send.assert_any_call(
-            request,
-            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
-            stream=endpoint.streaming,
+            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -155,18 +136,11 @@ class TestClient:
         request.method = "PUT"
 
         ServiceCaller.call(
-            service,
-            endpoint,
-            method="PUT",
-            session=mock_session,
-            timeout_spec=mock_timeout,
-            logger=mock_logger,
+            service, endpoint, method="PUT", session=mock_session, timeout_spec=mock_timeout, logger=mock_logger
         )
 
         mock_session.send.assert_any_call(
-            request,
-            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
-            stream=endpoint.streaming,
+            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
         )
 
     @mock.patch("apiron.client.ServiceCaller.get_adapted_session")
@@ -209,13 +183,7 @@ class TestClient:
         session = mock.Mock()
         session.send.return_value = mock_response
 
-        ServiceCaller.call(
-            service,
-            endpoint,
-            session=session,
-            logger=mock_logger,
-            encoding="FAKE-CODEC",
-        )
+        ServiceCaller.call(service, endpoint, session=session, logger=mock_logger, encoding="FAKE-CODEC")
 
         assert "FAKE-CODEC" == mock_response.encoding
 
@@ -246,12 +214,7 @@ class TestClient:
 @mock.patch("requests.Session", autospec=True)
 class TestClientStubCall:
     def test_call_stub(
-        self,
-        MockSession,
-        MockAdapter,
-        mock_build_request_object,
-        mock_get_adapted_session,
-        mock_timeout,
+        self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout
     ):
         """
         Test getting a response for a ``StubEndpoint``
@@ -269,12 +232,7 @@ class TestClientStubCall:
         assert expected_response == actual_response
 
     def test_call_stub_dynamic(
-        self,
-        MockSession,
-        MockAdapter,
-        mock_build_request_object,
-        mock_get_adapted_session,
-        mock_timeout,
+        self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout
     ):
         """
         Test getting a response for a ``StubEndpoint`` using a dynamic response
@@ -296,12 +254,7 @@ class TestClientStubCall:
         assert expected_response == actual_response
 
     def test_call_stub_dynamic_params(
-        self,
-        MockSession,
-        MockAdapter,
-        mock_build_request_object,
-        mock_get_adapted_session,
-        mock_timeout,
+        self, MockSession, MockAdapter, mock_build_request_object, mock_get_adapted_session, mock_timeout
     ):
         """
         Test getting a response for a ``StubEndpoint`` using a dynamic response with parameters
@@ -318,9 +271,7 @@ class TestClientStubCall:
 
         stub_endpoint.stub_response = stub_response
 
-        actual_response = ServiceCaller.call(
-            service, stub_endpoint, params={"param_key": "param_value"}
-        )
+        actual_response = ServiceCaller.call(service, stub_endpoint, params={"param_key": "param_value"})
 
         expected_response = "correct"
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -88,23 +88,17 @@ class TestEndpoint:
             assert issubclass(warning_records[-1].category, UserWarning)
 
     def test_get_merged_params(self):
-        foo = apiron.JsonEndpoint(
-            default_params={"foo": "bar"}, required_params={"baz"}
-        )
+        foo = apiron.JsonEndpoint(default_params={"foo": "bar"}, required_params={"baz"})
         assert {"foo": "bar", "baz": "qux"} == foo.get_merged_params({"baz": "qux"})
 
     def test_get_merged_params_with_unsupplied_param(self):
-        foo = apiron.JsonEndpoint(
-            default_params={"foo": "bar"}, required_params={"baz"}
-        )
+        foo = apiron.JsonEndpoint(default_params={"foo": "bar"}, required_params={"baz"})
 
         with pytest.raises(apiron.UnfulfilledParameterException):
             foo.get_merged_params()
 
     def test_get_merged_params_with_empty_param(self):
-        foo = apiron.JsonEndpoint(
-            default_params={"foo": "bar"}, required_params={"baz"}
-        )
+        foo = apiron.JsonEndpoint(default_params={"foo": "bar"}, required_params={"baz"})
 
         with warnings.catch_warnings(record=True) as warning_records:
             warnings.simplefilter("always")
@@ -113,9 +107,7 @@ class TestEndpoint:
             assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_get_merged_params_with_required_and_default_param(self):
-        foo = apiron.JsonEndpoint(
-            default_params={"foo": "bar"}, required_params={"foo"}
-        )
+        foo = apiron.JsonEndpoint(default_params={"foo": "bar"}, required_params={"foo"})
         assert {"foo": "bar"} == foo.get_merged_params()
 
     @mock.patch("apiron.client.requests.Session.send")
@@ -156,9 +148,7 @@ class TestStreamingEndpoint:
     def test_format_response(self):
         foo = apiron.StreamingEndpoint()
         mock_response = mock.Mock()
-        assert mock_response.iter_content(chunk_size=None) == foo.format_response(
-            mock_response
-        )
+        assert mock_response.iter_content(chunk_size=None) == foo.format_response(mock_response)
 
 
 class TestStubEndpoint:
@@ -204,10 +194,7 @@ class TestStubEndpoint:
 
         def _test_case(call_kwargs, expected_response):
             def stub_response(**kwargs):
-                if (
-                    kwargs.get("params")
-                    and kwargs["params"].get("param_key") == "param_value"
-                ):
+                if kwargs.get("params") and kwargs["params"].get("param_key") == "param_value":
                     return {"stub response": "for param_key=param_value"}
                 else:
                     return {"default": "response"}

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -10,7 +10,8 @@ import apiron
 @pytest.fixture
 def service():
     class SomeService(apiron.Service):
-        domain = 'http://foo.com'
+        domain = "http://foo.com"
+
     return SomeService
 
 
@@ -26,95 +27,103 @@ class TestEndpoint:
 
     def test_default_attributes_from_constructor(self):
         foo = apiron.Endpoint()
-        assert '/' == foo.path
-        assert 'GET' == foo.default_method
+        assert "/" == foo.path
+        assert "GET" == foo.default_method
 
     def test_constructor_stores_passed_attributes(self):
-        foo = apiron.Endpoint(path='/foo/', default_method='POST')
-        assert '/foo/' == foo.path
-        assert 'POST' == foo.default_method
+        foo = apiron.Endpoint(path="/foo/", default_method="POST")
+        assert "/foo/" == foo.path
+        assert "POST" == foo.default_method
 
     def test_format_response(self):
         foo = apiron.Endpoint()
         mock_response = mock.Mock()
-        mock_response.text = 'foobar'
-        assert 'foobar' == foo.format_response(mock_response)
+        mock_response.text = "foobar"
+        assert "foobar" == foo.format_response(mock_response)
 
     def test_required_headers(self):
         foo = apiron.Endpoint()
         assert {} == foo.required_headers
 
     def test_str_method(self):
-        foo = apiron.Endpoint(path='/foo/bar/')
-        assert '/foo/bar/' == str(foo)
+        foo = apiron.Endpoint(path="/foo/bar/")
+        assert "/foo/bar/" == str(foo)
 
     def test_path_placeholders_when_none_present(self):
         foo = apiron.Endpoint()
         assert [] == foo.path_placeholders
 
     def test_path_placeholders_when_present(self):
-        foo = apiron.Endpoint(path='/foo/{one}/{two}')
-        assert ['one', 'two'] == foo.path_placeholders
+        foo = apiron.Endpoint(path="/foo/{one}/{two}")
+        assert ["one", "two"] == foo.path_placeholders
 
     def test_format_path_with_correct_kwargs(self):
-        foo = apiron.Endpoint(path='/{one}/{two}/')
-        path_kwargs = {'one': 'foo', 'two': 'bar'}
-        assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
+        foo = apiron.Endpoint(path="/{one}/{two}/")
+        path_kwargs = {"one": "foo", "two": "bar"}
+        assert "/foo/bar/" == foo.get_formatted_path(**path_kwargs)
 
     def test_format_path_with_incorrect_kwargs(self):
-        foo = apiron.Endpoint(path='/{one}/{two}/')
-        path_kwargs = {'foo': 'bar'}
+        foo = apiron.Endpoint(path="/{one}/{two}/")
+        path_kwargs = {"foo": "bar"}
         with pytest.raises(KeyError):
             with warnings.catch_warnings(record=True) as warning_records:
-                warnings.simplefilter('always')
+                warnings.simplefilter("always")
                 foo.get_formatted_path(**path_kwargs)
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_format_path_with_extra_kwargs(self):
-        foo = apiron.Endpoint(path='/{one}/{two}/')
-        path_kwargs = {'one': 'foo', 'two': 'bar', 'three': 'not used'}
+        foo = apiron.Endpoint(path="/{one}/{two}/")
+        path_kwargs = {"one": "foo", "two": "bar", "three": "not used"}
         with warnings.catch_warnings(record=True) as warning_records:
-            assert '/foo/bar/' == foo.get_formatted_path(**path_kwargs)
+            assert "/foo/bar/" == foo.get_formatted_path(**path_kwargs)
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_query_parameter_in_path_generates_warning(self):
         with warnings.catch_warnings(record=True) as warning_records:
-            warnings.simplefilter('always')
-            _ = apiron.Endpoint(path='/?foo=bar')
+            warnings.simplefilter("always")
+            _ = apiron.Endpoint(path="/?foo=bar")
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, UserWarning)
 
     def test_get_merged_params(self):
-        foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
-        assert {'foo': 'bar', 'baz': 'qux'} == foo.get_merged_params({'baz': 'qux'})
+        foo = apiron.JsonEndpoint(
+            default_params={"foo": "bar"}, required_params={"baz"}
+        )
+        assert {"foo": "bar", "baz": "qux"} == foo.get_merged_params({"baz": "qux"})
 
     def test_get_merged_params_with_unsupplied_param(self):
-        foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
+        foo = apiron.JsonEndpoint(
+            default_params={"foo": "bar"}, required_params={"baz"}
+        )
 
         with pytest.raises(apiron.UnfulfilledParameterException):
             foo.get_merged_params()
 
     def test_get_merged_params_with_empty_param(self):
-        foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'baz'})
+        foo = apiron.JsonEndpoint(
+            default_params={"foo": "bar"}, required_params={"baz"}
+        )
 
         with warnings.catch_warnings(record=True) as warning_records:
-            warnings.simplefilter('always')
-            assert {'foo': 'bar', 'baz': None} == foo.get_merged_params({'baz': None})
+            warnings.simplefilter("always")
+            assert {"foo": "bar", "baz": None} == foo.get_merged_params({"baz": None})
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, RuntimeWarning)
 
     def test_get_merged_params_with_required_and_default_param(self):
-        foo = apiron.JsonEndpoint(default_params={'foo': 'bar'}, required_params={'foo'})
-        assert {'foo': 'bar'} == foo.get_merged_params()
+        foo = apiron.JsonEndpoint(
+            default_params={"foo": "bar"}, required_params={"foo"}
+        )
+        assert {"foo": "bar"} == foo.get_merged_params()
 
-    @mock.patch('apiron.client.requests.Session.send')
+    @mock.patch("apiron.client.requests.Session.send")
     def test_using_path_kwargs_produces_warning(self, mock_send, service):
-        service.foo = apiron.Endpoint(path='/foo/{one}')
+        service.foo = apiron.Endpoint(path="/foo/{one}")
         with warnings.catch_warnings(record=True) as warning_records:
-            warnings.simplefilter('always')
-            _ = service.foo(path_kwargs={'one': 'bar'})
+            warnings.simplefilter("always")
+            _ = service.foo(path_kwargs={"one": "bar"})
             assert 1 == len(warning_records)
             assert issubclass(warning_records[-1].category, RuntimeWarning)
 
@@ -124,30 +133,32 @@ class TestJsonEndpoint:
         foo = apiron.JsonEndpoint()
         mock_response = mock.Mock()
 
-        with mock.patch.object(mock_response, 'json') as mock_json:
-            mock_json.return_value = {'foo': 'bar'}
-            assert {'foo': 'bar'} == foo.format_response(mock_response)
+        with mock.patch.object(mock_response, "json") as mock_json:
+            mock_json.return_value = {"foo": "bar"}
+            assert {"foo": "bar"} == foo.format_response(mock_response)
             mock_json.assert_called_once_with(object_pairs_hook=None)
 
     def test_format_response_when_ordered(self):
         foo = apiron.JsonEndpoint(preserve_order=True)
         mock_response = mock.Mock()
 
-        with mock.patch.object(mock_response, 'json') as mock_json:
-            mock_json.return_value = {'foo': 'bar'}
-            assert {'foo': 'bar'} == foo.format_response(mock_response)
+        with mock.patch.object(mock_response, "json") as mock_json:
+            mock_json.return_value = {"foo": "bar"}
+            assert {"foo": "bar"} == foo.format_response(mock_response)
             mock_json.assert_called_once_with(object_pairs_hook=collections.OrderedDict)
 
     def test_required_headers(self):
         foo = apiron.JsonEndpoint()
-        assert {'Accept': 'application/json'} == foo.required_headers
+        assert {"Accept": "application/json"} == foo.required_headers
 
 
 class TestStreamingEndpoint:
     def test_format_response(self):
         foo = apiron.StreamingEndpoint()
         mock_response = mock.Mock()
-        assert mock_response.iter_content(chunk_size=None) == foo.format_response(mock_response)
+        assert mock_response.iter_content(chunk_size=None) == foo.format_response(
+            mock_response
+        )
 
 
 class TestStubEndpoint:
@@ -155,25 +166,25 @@ class TestStubEndpoint:
         """
         Test initializing a stub endpoint with a stub response
         """
-        stub_endpoint = apiron.StubEndpoint(stub_response='stub response')
-        assert 'stub response' == stub_endpoint.stub_response
+        stub_endpoint = apiron.StubEndpoint(stub_response="stub response")
+        assert "stub response" == stub_endpoint.stub_response
 
     def test_extra_params(self):
         """
         Test initializing a stub endpoint with extra params
         """
         stub_endpoint = apiron.StubEndpoint(
-            stub_response='stub response',
-            path='/some/path/',
-            default_params={'param_name': 'param_val'},
-            required_params={'param_name'},
-            arbitrary_kwarg='foo',
+            stub_response="stub response",
+            path="/some/path/",
+            default_params={"param_name": "param_val"},
+            required_params={"param_name"},
+            arbitrary_kwarg="foo",
         )
         expected_params = {
-            'path': '/some/path/',
-            'default_params': {'param_name': 'param_val'},
-            'required_params': {'param_name'},
-            'arbitrary_kwarg': 'foo',
+            "path": "/some/path/",
+            "default_params": {"param_name": "param_val"},
+            "required_params": {"param_name"},
+            "arbitrary_kwarg": "foo",
         }
         assert expected_params == stub_endpoint.endpoint_params
 
@@ -181,38 +192,37 @@ class TestStubEndpoint:
         """
         Test calling a ``StubEndpoint`` with a static response
         """
-        service.stub_endpoint = apiron.StubEndpoint(
-            stub_response='stub response',
-        )
+        service.stub_endpoint = apiron.StubEndpoint(stub_response="stub response")
         actual_response = service.stub_endpoint()
-        expected_response = 'stub response'
+        expected_response = "stub response"
         assert actual_response == expected_response
 
     def test_call_dynamic(self, service):
         """
         Test calling a StubEndpoint with a dynamic response
         """
+
         def _test_case(call_kwargs, expected_response):
             def stub_response(**kwargs):
-                if kwargs.get('params') and kwargs['params'].get('param_key') == 'param_value':
-                    return {'stub response': 'for param_key=param_value'}
+                if (
+                    kwargs.get("params")
+                    and kwargs["params"].get("param_key") == "param_value"
+                ):
+                    return {"stub response": "for param_key=param_value"}
                 else:
-                    return {'default': 'response'}
+                    return {"default": "response"}
 
             service.stub_endpoint = apiron.StubEndpoint(stub_response=stub_response)
             actual_response = service.stub_endpoint(**call_kwargs)
             assert actual_response == expected_response
 
+        _test_case(call_kwargs={}, expected_response={"default": "response"})
         _test_case(
-            call_kwargs={},
-            expected_response={'default': 'response'},
-        )
-        _test_case(
-            call_kwargs={'params': {'param_key': 'param_value'}},
-            expected_response={'stub response': 'for param_key=param_value'},
+            call_kwargs={"params": {"param_key": "param_value"}},
+            expected_response={"stub response": "for param_key=param_value"},
         )
 
     def test_call_without_service_raises_exception(self):
-        stub_endpoint = apiron.StubEndpoint(stub_response='foo')
+        stub_endpoint = apiron.StubEndpoint(stub_response="foo")
         with pytest.raises(TypeError):
             stub_endpoint()


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [x] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite passing?
- [ ] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**
Makes use of the concept of "stages" on Travis CI. There is one stage
each here for linting, testing, and deploying. The deploy stage is now
cut off at the pass if the target is not a tag from the master branch,
so the build should be slightly faster.

**How does this change work?**
* Install [`black`](https://github.com/ambv/black) for consistent code formatting
* Run `black --check` on the code to see if it's been properly formatted, failing if not
* Install [`pyflakes`](https://github.com/PyCQA/pyflakes) for static analysis
* Run `pyflakes` on the code, failing if any errors found

<img width="386" alt="Screenshot 2019-04-22 10 31 35" src="https://user-images.githubusercontent.com/1808306/56505497-d843f280-64e9-11e9-9402-74501bddb366.png">