### PR TITLE
Replace metaclass behavior with descriptor protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Move to the descriptor protocol from metaclassing under the hood for turning an endpoint into a callable
+
 ## [2.5.0] - 2019-04-18
 ### Added
 - Ability to pass dict to `json` keyword argument for raw POST body instead of form-encoded data

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -20,6 +20,9 @@ class Endpoint:
         update_wrapper(caller, ServiceCaller.call)
         return caller
 
+    def __call__(self):
+        raise TypeError("Endpoints are only callable in conjunction with a Service class.")
+
     def __init__(self, path="/", default_method="GET", default_params=None, required_params=None):
         """
         :param str path:

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -1,3 +1,8 @@
+from functools import partial, update_wrapper
+
+from apiron import ServiceCaller
+
+
 class StubEndpoint:
     """
     A stub endpoint designed to return a pre-baked response
@@ -6,16 +11,10 @@ class StubEndpoint:
     before the endpoint is complete.
     """
 
-    def __call__(self, *args, **kwargs):
-        """
-        Used to provide syntax sugar on top of :func:`apiron.client.ServiceCaller.call`.
-        The callable attribute is set dynamically by the :class:`Service` subclass this endpoint is a part of.
-        Arguments are identical to those of :func:`apiron.client.ServiceCaller.call`
-        """
-        if hasattr(self, "callable"):
-            return self.callable(*args, **kwargs)
-        else:
-            raise TypeError("Endpoints are only callable in conjunction with a Service class.")
+    def __get__(self, instance, owner):
+        caller = partial(ServiceCaller.call, owner, self)
+        update_wrapper(caller, ServiceCaller.call)
+        return caller
 
     def __init__(self, stub_response=None, **kwargs):
         """

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -16,6 +16,9 @@ class StubEndpoint:
         update_wrapper(caller, ServiceCaller.call)
         return caller
 
+    def __call__(self):
+        raise TypeError("Endpoints are only callable in conjunction with a Service class.")
+
     def __init__(self, stub_response=None, **kwargs):
         """
         :param stub_response:

--- a/apiron/service/base.py
+++ b/apiron/service/base.py
@@ -1,19 +1,7 @@
-from functools import partial
-
-from apiron.client import ServiceCaller
-from apiron.endpoint import Endpoint, StubEndpoint
-
-
 class ServiceMeta(type):
     @property
     def required_headers(cls):
         return cls().required_headers
-
-    def __getattribute__(cls, *args):
-        attribute = type.__getattribute__(cls, *args)
-        if isinstance(attribute, Endpoint) or isinstance(attribute, StubEndpoint):
-            attribute.callable = partial(ServiceCaller.call, cls, attribute)
-        return attribute
 
     def __str__(cls):
         return str(cls())


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Using the descriptor protocol allows for inspecting the service that
owns an endpoint, giving an easier entrypoint for applying
ServiceCaller.call than doing this in the ServiceMeta metaclass.

**How does this change work?**
Add `__get__` to Endpoint classes that does the job that `ServiceMeta.__getattribute__` used to.
This lets the Endpoint do the work and stops the ServiceMeta from needing to know the specifics of the endpoints attached to it.

**Additional context**
I had wanted exactly this interaction from the beginning but didn't make the
connection that descriptors would get me there. It feels like this may also
pave the road to better code introspection as laid out in #54.
