### PR TITLE
Provide optional allow_redirects parameter for enabling/disabling HTTP redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to pass optional parameter `allow_redirects` to enable/disable HTTP redirection when calling an endpoint
+
 ### Changed
 - Move to the descriptor protocol from metaclassing under the hood for turning an endpoint into a callable
-- Ability to pass optional parameter `allow_redirects` to enable/disable HTTP redirection when calling an endpoint
 
 ## [2.5.0] - 2019-04-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Move to the descriptor protocol from metaclassing under the hood for turning an endpoint into a callable
+- Ability to pass optional parameter `allow_redirects` to enable/disable HTTP redirection when calling an endpoint
 
 ## [2.5.0] - 2019-04-18
 ### Added

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -162,6 +162,7 @@ class ServiceCaller:
         retry_spec=DEFAULT_RETRY,
         timeout_spec=DEFAULT_TIMEOUT,
         logger=None,
+        allow_redirects=True,
         **kwargs
     ):
         """
@@ -214,6 +215,10 @@ class ServiceCaller:
         :param logging.Logger logger:
             (optional)
             An existing logger for logging from the proper caller for better correlation
+        :param bool allow_redirects:
+            (optional)
+            Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection
+            (default ``True``)
         :return:
             The result of ``endpoint``'s :func:`format_response`
         :rtype: The type returned by ``endpoint``'s :func:`format_response`
@@ -267,6 +272,7 @@ class ServiceCaller:
             request,
             timeout=(timeout_spec.connection_timeout, timeout_spec.read_timeout),
             stream=getattr(endpoint, "streaming", False),
+            allow_redirects=allow_redirects
         )
 
         logger.info(

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -272,7 +272,7 @@ class ServiceCaller:
             request,
             timeout=(timeout_spec.connection_timeout, timeout_spec.read_timeout),
             stream=getattr(endpoint, "streaming", False),
-            allow_redirects=allow_redirects
+            allow_redirects=allow_redirects,
         )
 
         logger.info(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,7 +118,7 @@ class TestClient:
             request,
             timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
             stream=endpoint.streaming,
-            allow_redirects=True
+            allow_redirects=True,
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -133,7 +133,7 @@ class TestClient:
             request,
             timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
             stream=endpoint.streaming,
-            allow_redirects=True
+            allow_redirects=True,
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -149,7 +149,7 @@ class TestClient:
             request,
             timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
             stream=endpoint.streaming,
-            allow_redirects=True
+            allow_redirects=True,
         )
 
     @mock.patch("apiron.client.ServiceCaller.get_adapted_session")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,7 +115,10 @@ class TestClient:
 
         mock_get_adapted_session.assert_called_once_with(MockAdapter())
         mock_session.send.assert_called_once_with(
-            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
+            request,
+            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
+            stream=endpoint.streaming,
+            allow_redirects=True
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -127,7 +130,10 @@ class TestClient:
         ServiceCaller.call(service, endpoint, session=mock_session, timeout_spec=mock_timeout, logger=mock_logger)
 
         mock_session.send.assert_any_call(
-            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
+            request,
+            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
+            stream=endpoint.streaming,
+            allow_redirects=True
         )
 
         mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
@@ -140,7 +146,10 @@ class TestClient:
         )
 
         mock_session.send.assert_any_call(
-            request, timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout), stream=endpoint.streaming
+            request,
+            timeout=(mock_timeout.connection_timeout, mock_timeout.read_timeout),
+            stream=endpoint.streaming,
+            allow_redirects=True
         )
 
     @mock.patch("apiron.client.ServiceCaller.get_adapted_session")


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
The `requests` library provides a mechanism to enable/disable HTTP redirects. This simple enhancement exposes this option in `apiron`.

**How does this change work?**
Passes the `allow_redirects` parameter to the `requests.send()` function. Defaults to `True`.

