### PR TITLE
Add test for bug fixed in 2.6.1 for stub endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- More testing for the bug fixed in v2.6.1
+
 ## [2.6.1] - 2019-06-06
 ### Added
 - Backwards compatibility to allow `ServiceCaller.call()` to use endpoints that live in an instantiated `Service`

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -212,3 +212,7 @@ class TestStubEndpoint:
         stub_endpoint = apiron.StubEndpoint(stub_response="foo")
         with pytest.raises(TypeError):
             stub_endpoint()
+
+    def test_call_with_initialized_service_works(self, service):
+        service.stub = apiron.StubEndpoint(stub_response="foo")
+        assert ServiceCaller.call(service(), service().stub) == "foo"


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**
Increases coverage back to 100%, providing a test case to ensure the bug fixed in v2.6.1 does not affect stub endpoints.

**How does this change work?**
Provides a test for the case when a stub endpoint is used in an initialized `Service` instance.
