### PR TITLE
Fix condition for deployments from Travis CI (#61)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ stages:
   - lint
   - test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 jobs:
   include:
@@ -46,10 +46,6 @@ jobs:
             - dist/apiron-*-py3-none-any.whl
             - dist/apiron-*.tar.gz
           skip_cleanup: true
-          on:
-            repo: ithaka/apiron
-            branch: master
-            tags: true
 
         - &pypi  # Production PyPI
           provider: pypi
@@ -58,10 +54,6 @@ jobs:
             secure: 'Y9qZ8MzvisM3VNMeiL9yL9RkIyW8qzcvrpSkzf0haz2tLtMoidW8mXoC2pj5g5iXTLrK5uG/5PHrJ7loWns4BvDHU/amhzTm+m5vu6De4PSlKRy4uqnR7CtbsfbeR2+wz9YnPuejr/iP5yQSpZS2EokdsG4kXAVgdVTNA9M9l3vdlt04hN/knszmUv6L7Exd4YV390POTwzVFnXX9QpMy2S2JVHQfn3ZvYd+yurNb92b5IsXXxVAdcFniAhfyThSX5Yo1I1QoD2zINB/3IfYndm5/W715SASNCvZdDPuA7cOsuQBuyb2ImNbmG9y8TW8ll9owuGTfZUQ3jqYijH5TwKH6+CEM2fYKFJ2s2/9DsJyW3wl9CHfWBPfj3weOoFfVxVHYBz5eqRoL7j7qYPJgibnJM6+6h8HRDMsiOB5OJqZDXupxBhCVJc8SjLnEQjjJPYbScVXobh6NAH5r51hti41jUhy4XEqjW3TiaYQP4v8FcPOVog0eH5MXN7C/BYrQ0vHrOHs0Yb60LZGXMlAZYKO0mNV7mhgaOjwIEr0w1zROKAUMWvOH2WgiPOJDOxS2mrjej+f60zVjgAmRw19O63M2qczjbUnOda+hfqV7QodurWLwq7OPJEkeK2KfjVvUqqnlhfuVgc7XFsAuPnsf1jJFtOV0vdwYkDb9Ah6/Ho='
           skip_cleanup: true
           skip_existing: true
-          on:
-            repo: ithaka/apiron
-            branch: master
-            tags: true
 
         - <<: *pypi  # Test PyPI
           server: 'https://test.pypi.org/legacy/'


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**
Closes #61 (hopefully)

**How does this change work?**

Per Travis CI, because a tag is never associated with a branch, receiving a webhook caused by a tag won't ever meet the condition that the branch is `master`.

**Additional context**

Additionally, since the criteria for the deploy stage is specified in the stage configuration, it no longer needs to be in the provider configuration.
