### PR TITLE
Remove ServiceCaller and path_kwargs vestiges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Extract `ServiceCaller` behaviors to module level and remove class
+- Remove `path_kwargs` argument from the `call` function (previously a `ServiceCaller` method)
 
 ## [2.6.1] - 2019-06-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - More testing for the bug fixed in v2.6.1
 
+### Changed
+- Extract `ServiceCaller` behaviors to module level and remove class
+
 ## [2.6.1] - 2019-06-06
 ### Added
 - Backwards compatibility to allow `ServiceCaller.call()` to use endpoints that live in an instantiated `Service`

--- a/apiron/__init__.py
+++ b/apiron/__init__.py
@@ -1,4 +1,4 @@
-from apiron.client import ServiceCaller, Timeout
+from apiron.client import Timeout
 from apiron.endpoint import Endpoint, JsonEndpoint, StreamingEndpoint, StubEndpoint
 from apiron.exceptions import APIException, NoHostsAvailableException, UnfulfilledParameterException
 from apiron.service import DiscoverableService, Service, ServiceBase
@@ -11,7 +11,6 @@ __all__ = [
     "NoHostsAvailableException",
     "Service",
     "ServiceBase",
-    "ServiceCaller",
     "StreamingEndpoint",
     "StubEndpoint",
     "Timeout",

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -1,7 +1,6 @@
 import collections
 import logging
 import random
-import warnings
 from urllib import parse
 
 import requests

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -195,6 +195,8 @@ def call(
         (optional)
         Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection
         (default ``True``)
+    :param ``**kwargs``:
+        Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
     :return:
         The result of ``endpoint``'s :func:`format_response`
     :rtype: The type returned by ``endpoint``'s :func:`format_response`

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -31,264 +31,256 @@ DEFAULT_RETRY = retry.Retry(
 )
 
 
-class ServiceCaller:
+def build_url(host, path):
     """
-    A class for calling :mod:`services <apiron.service.base>`
+    Builds a valid URL from a host and path which may or may not have slashes in the proper place.
+    Does not conform to `IETF RFC 1808 <https://tools.ietf.org/html/rfc1808.html>`_ but instead joins the host and path as given.
+    Does not append any additional slashes to the final URL; just joins the host and path properly.
+
+    :param str host:
+        An HTTP host like ``'https://awesome-api.com/v2'``
+    :param str path:
+        The path to an endpoint on the host like ``'/some-resource/'``
+    :return:
+        The properly-joined URL of host and path, e.g. ``'https://awesome-api.com/v2/some-resource/'``
+    :rtype:
+        str
     """
+    host += "/" if not host.endswith("/") else ""
+    path = path.lstrip("/")
 
-    @staticmethod
-    def build_url(host, path):
-        """
-        Builds a valid URL from a host and path which may or may not have slashes in the proper place.
-        Does not conform to `IETF RFC 1808 <https://tools.ietf.org/html/rfc1808.html>`_ but instead joins the host and path as given.
-        Does not append any additional slashes to the final URL; just joins the host and path properly.
+    return parse.urljoin(host, path)
 
-        :param str host:
-            An HTTP host like ``'https://awesome-api.com/v2'``
-        :param str path:
-            The path to an endpoint on the host like ``'/some-resource/'``
-        :return:
-            The properly-joined URL of host and path, e.g. ``'https://awesome-api.com/v2/some-resource/'``
-        :rtype:
-            str
-        """
-        host += "/" if not host.endswith("/") else ""
-        path = path.lstrip("/")
 
-        return parse.urljoin(host, path)
+def get_adapted_session(adapter):
+    """
+    Mounts an adapter capable of communication over HTTP or HTTPS to the supplied session.
 
-    @staticmethod
-    def get_adapted_session(adapter):
-        """
-        Mounts an adapter capable of communication over HTTP or HTTPS to the supplied session.
+    :param adapter:
+        A :class:`requests.adapters.HTTPAdapter` instance
+    :return:
+        The adapted :class:`requests.Session` instance
+    """
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
-        :param adapter:
-            A :class:`requests.adapters.HTTPAdapter` instance
-        :return:
-            The adapted :class:`requests.Session` instance
-        """
-        session = requests.Session()
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
-        return session
 
-    @staticmethod
-    def get_required_headers(service, endpoint):
-        """
-        :param Service service:
-            The service being called
-        :param Endpoint endpoint:
-            The endpoint being called
-        :return:
-            Headers required by the ``service`` and the ``endpoint`` being called
-        :rtype:
-            dict
-        """
-        headers = {}
-        headers.update(service.required_headers)
-        headers.update(endpoint.required_headers)
-        return headers
+def get_required_headers(service, endpoint):
+    """
+    :param Service service:
+        The service being called
+    :param Endpoint endpoint:
+        The endpoint being called
+    :return:
+        Headers required by the ``service`` and the ``endpoint`` being called
+    :rtype:
+        dict
+    """
+    headers = {}
+    headers.update(service.required_headers)
+    headers.update(endpoint.required_headers)
+    return headers
 
-    @staticmethod
-    def choose_host(service):
-        hosts = service.get_hosts()
-        if not hosts:
-            raise NoHostsAvailableException(service.service_name)
-        return random.choice(hosts)
 
-    @classmethod
-    def build_request_object(
-        cls,
+def choose_host(service):
+    hosts = service.get_hosts()
+    if not hosts:
+        raise NoHostsAvailableException(service.service_name)
+    return random.choice(hosts)
+
+
+def build_request_object(
+    session,
+    service,
+    endpoint,
+    method=None,
+    path_kwargs=None,
+    params=None,
+    data=None,
+    json=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    **kwargs
+):
+    host = choose_host(service=service)
+
+    if path_kwargs:
+        warnings.warn(
+            "path_kwargs is no longer necessary and will be removed in a future version of apiron. "
+            "You can call endpoints using plain keyword arguments instead!",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+
+    path_kwargs = path_kwargs or {}
+    path_kwargs.update(**kwargs)
+    path = endpoint.get_formatted_path(**path_kwargs)
+
+    merged_params = endpoint.get_merged_params(params)
+
+    headers = headers or {}
+    headers.update(get_required_headers(service, endpoint))
+
+    request = requests.Request(
+        method=method or endpoint.default_method,
+        url=build_url(host, path),
+        params=merged_params,
+        data=data,
+        json=json,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+    )
+
+    return session.prepare_request(request)
+
+
+def call(
+    service,
+    endpoint,
+    method=None,
+    path_kwargs=None,
+    session=None,
+    params=None,
+    data=None,
+    json=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    encoding=None,
+    retry_spec=DEFAULT_RETRY,
+    timeout_spec=DEFAULT_TIMEOUT,
+    logger=None,
+    allow_redirects=True,
+    **kwargs
+):
+    """
+    :param Service service:
+        The service that hosts the endpoint being called
+    :param Endpoint endpoint:
+        The endpoint being called
+    :param str method:
+        The HTTP method to use for the call
+    :param dict path_kwargs:
+        Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
+        (default ``None``)
+    :param requests.Session session:
+        (optional)
+        An existing session, useful for making many calls in a single session
+        (default ``None``)
+    :param dict params:
+        (optional)
+        ``GET`` parameters to send to the endpoint
+        (default ``None``)
+    :param dict data:
+        (optional)
+        ``POST`` data to send to the endpoint.
+        A :class:`dict` will be form-encoded, while a :class:`str` will be sent raw
+        (default ``None``)
+    :param dict json:
+        (optional)
+        A JSON-serializable dictionary that will be sent as the ``POST`` body
+        (default ``None``)
+    :param dict headers:
+        HTTP Headers to send to the endpoint
+        (default ``None``)
+    :param dict cookies:
+        Cookies to send to the endpoint
+        (default ``None``)
+    :param auth:
+        An object suitable for the :class:`requests.Request` object's ``auth`` argument
+    :param str encoding:
+        The codec to use when decoding the response.
+        Default behavior is to have ``requests`` guess the codec.
+        (default ``None``)
+    :param urllib3.util.retry.Retry retry_spec:
+        (optional)
+        An override of the retry behavior for this call.
+        (default ``Retry(total=1, connect=1, read=1, status_forcelist=[500-level status codes])``)
+    :param Timeout timeout_spec:
+        (optional)
+        An override of the timeout behavior for this call.
+        (default ``Timeout(connection_timeout=1, read_timeout=3)``)
+    :param logging.Logger logger:
+        (optional)
+        An existing logger for logging from the proper caller for better correlation
+    :param bool allow_redirects:
+        (optional)
+        Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection
+        (default ``True``)
+    :return:
+        The result of ``endpoint``'s :func:`format_response`
+    :rtype: The type returned by ``endpoint``'s :func:`format_response`
+    :raises requests.RetryError:
+        if retry threshold exceeded due to bad HTTP codes (default 500 range)
+    :raises requests.ConnectionError:
+        if retry threshold exceeded due to connection or request timeouts
+    """
+    logger = logger or LOGGER
+
+    if hasattr(endpoint, "stub_response"):
+        logger.info("Stub call for endpoint defined by {}".format(getattr(endpoint, "endpoint_params", {})))
+        if callable(endpoint.stub_response):
+            return endpoint.stub_response(
+                method=method or getattr(endpoint, "default_method", "GET"),
+                path_kwargs=path_kwargs,
+                params=params,
+                data=data,
+                json=json,
+                headers=headers,
+                cookies=cookies,
+                auth=auth,
+            )
+        else:
+            return endpoint.stub_response
+
+    managing_session = False
+
+    if not session:
+        session = get_adapted_session(adapters.HTTPAdapter(max_retries=retry_spec))
+        managing_session = True
+
+    request = build_request_object(
         session,
         service,
         endpoint,
-        method=None,
-        path_kwargs=None,
-        params=None,
-        data=None,
-        json=None,
-        headers=None,
-        cookies=None,
-        auth=None,
+        method=method or endpoint.default_method,
+        path_kwargs=path_kwargs,
+        params=params,
+        data=data,
+        json=json,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
         **kwargs
-    ):
-        host = cls.choose_host(service=service)
+    )
 
-        if path_kwargs:
-            warnings.warn(
-                "path_kwargs is no longer necessary and will be removed in a future version of apiron. "
-                "You can call endpoints using plain keyword arguments instead!",
-                RuntimeWarning,
-                stacklevel=4,
-            )
+    logger.info("{method} {url}".format(method=method or endpoint.default_method, url=request.url))
 
-        path_kwargs = path_kwargs or {}
-        path_kwargs.update(**kwargs)
-        path = endpoint.get_formatted_path(**path_kwargs)
+    response = session.send(
+        request,
+        timeout=(timeout_spec.connection_timeout, timeout_spec.read_timeout),
+        stream=getattr(endpoint, "streaming", False),
+        allow_redirects=allow_redirects,
+    )
 
-        merged_params = endpoint.get_merged_params(params)
-
-        headers = headers or {}
-        headers.update(cls.get_required_headers(service, endpoint))
-
-        request = requests.Request(
-            method=method or endpoint.default_method,
-            url=cls.build_url(host, path),
-            params=merged_params,
-            data=data,
-            json=json,
-            headers=headers,
-            cookies=cookies,
-            auth=auth,
+    logger.info(
+        "{status} {url}{history}".format(
+            status=response.status_code,
+            url=response.url,
+            history=" ({} redirect(s))".format(len(response.history)) if response.history else "",
         )
+    )
 
-        return session.prepare_request(request)
+    if managing_session:
+        session.close()
 
-    @classmethod
-    def call(
-        cls,
-        service,
-        endpoint,
-        method=None,
-        path_kwargs=None,
-        session=None,
-        params=None,
-        data=None,
-        json=None,
-        headers=None,
-        cookies=None,
-        auth=None,
-        encoding=None,
-        retry_spec=DEFAULT_RETRY,
-        timeout_spec=DEFAULT_TIMEOUT,
-        logger=None,
-        allow_redirects=True,
-        **kwargs
-    ):
-        """
-        :param Service service:
-            The service that hosts the endpoint being called
-        :param Endpoint endpoint:
-            The endpoint being called
-        :param str method:
-            The HTTP method to use for the call
-        :param dict path_kwargs:
-            Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
-            (default ``None``)
-        :param requests.Session session:
-            (optional)
-            An existing session, useful for making many calls in a single session
-            (default ``None``)
-        :param dict params:
-            (optional)
-            ``GET`` parameters to send to the endpoint
-            (default ``None``)
-        :param dict data:
-            (optional)
-            ``POST`` data to send to the endpoint.
-            A :class:`dict` will be form-encoded, while a :class:`str` will be sent raw
-            (default ``None``)
-        :param dict json:
-            (optional)
-            A JSON-serializable dictionary that will be sent as the ``POST`` body
-            (default ``None``)
-        :param dict headers:
-            HTTP Headers to send to the endpoint
-            (default ``None``)
-        :param dict cookies:
-            Cookies to send to the endpoint
-            (default ``None``)
-        :param auth:
-            An object suitable for the :class:`requests.Request` object's ``auth`` argument
-        :param str encoding:
-            The codec to use when decoding the response.
-            Default behavior is to have ``requests`` guess the codec.
-            (default ``None``)
-        :param urllib3.util.retry.Retry retry_spec:
-            (optional)
-            An override of the retry behavior for this call.
-            (default ``Retry(total=1, connect=1, read=1, status_forcelist=[500-level status codes])``)
-        :param Timeout timeout_spec:
-            (optional)
-            An override of the timeout behavior for this call.
-            (default ``Timeout(connection_timeout=1, read_timeout=3)``)
-        :param logging.Logger logger:
-            (optional)
-            An existing logger for logging from the proper caller for better correlation
-        :param bool allow_redirects:
-            (optional)
-            Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection
-            (default ``True``)
-        :return:
-            The result of ``endpoint``'s :func:`format_response`
-        :rtype: The type returned by ``endpoint``'s :func:`format_response`
-        :raises requests.RetryError:
-            if retry threshold exceeded due to bad HTTP codes (default 500 range)
-        :raises requests.ConnectionError:
-            if retry threshold exceeded due to connection or request timeouts
-        """
-        logger = logger or LOGGER
+    response.raise_for_status()
 
-        if hasattr(endpoint, "stub_response"):
-            logger.info("Stub call for endpoint defined by {}".format(getattr(endpoint, "endpoint_params", {})))
-            if callable(endpoint.stub_response):
-                return endpoint.stub_response(
-                    method=method or getattr(endpoint, "default_method", "GET"),
-                    path_kwargs=path_kwargs,
-                    params=params,
-                    data=data,
-                    json=json,
-                    headers=headers,
-                    cookies=cookies,
-                    auth=auth,
-                )
-            else:
-                return endpoint.stub_response
+    if encoding:
+        response.encoding = encoding
 
-        managing_session = False
-
-        if not session:
-            session = cls.get_adapted_session(adapters.HTTPAdapter(max_retries=retry_spec))
-            managing_session = True
-
-        request = cls.build_request_object(
-            session,
-            service,
-            endpoint,
-            method=method or endpoint.default_method,
-            path_kwargs=path_kwargs,
-            params=params,
-            data=data,
-            json=json,
-            headers=headers,
-            cookies=cookies,
-            auth=auth,
-            **kwargs
-        )
-
-        logger.info("{method} {url}".format(method=method or endpoint.default_method, url=request.url))
-
-        response = session.send(
-            request,
-            timeout=(timeout_spec.connection_timeout, timeout_spec.read_timeout),
-            stream=getattr(endpoint, "streaming", False),
-            allow_redirects=allow_redirects,
-        )
-
-        logger.info(
-            "{status} {url}{history}".format(
-                status=response.status_code,
-                url=response.url,
-                history=" ({} redirect(s))".format(len(response.history)) if response.history else "",
-            )
-        )
-
-        if managing_session:
-            session.close()
-
-        response.raise_for_status()
-
-        if encoding:
-            response.encoding = encoding
-
-        return endpoint.format_response(response)
+    return endpoint.format_response(response)

--- a/apiron/client.py
+++ b/apiron/client.py
@@ -96,7 +96,6 @@ def build_request_object(
     service,
     endpoint,
     method=None,
-    path_kwargs=None,
     params=None,
     data=None,
     json=None,
@@ -107,17 +106,7 @@ def build_request_object(
 ):
     host = choose_host(service=service)
 
-    if path_kwargs:
-        warnings.warn(
-            "path_kwargs is no longer necessary and will be removed in a future version of apiron. "
-            "You can call endpoints using plain keyword arguments instead!",
-            RuntimeWarning,
-            stacklevel=4,
-        )
-
-    path_kwargs = path_kwargs or {}
-    path_kwargs.update(**kwargs)
-    path = endpoint.get_formatted_path(**path_kwargs)
+    path = endpoint.get_formatted_path(**kwargs)
 
     merged_params = endpoint.get_merged_params(params)
 
@@ -142,7 +131,6 @@ def call(
     service,
     endpoint,
     method=None,
-    path_kwargs=None,
     session=None,
     params=None,
     data=None,
@@ -164,9 +152,6 @@ def call(
         The endpoint being called
     :param str method:
         The HTTP method to use for the call
-    :param dict path_kwargs:
-        Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
-        (default ``None``)
     :param requests.Session session:
         (optional)
         An existing session, useful for making many calls in a single session
@@ -226,7 +211,6 @@ def call(
         if callable(endpoint.stub_response):
             return endpoint.stub_response(
                 method=method or getattr(endpoint, "default_method", "GET"),
-                path_kwargs=path_kwargs,
                 params=params,
                 data=data,
                 json=json,
@@ -248,7 +232,6 @@ def call(
         service,
         endpoint,
         method=method or endpoint.default_method,
-        path_kwargs=path_kwargs,
         params=params,
         data=data,
         json=json,

--- a/apiron/endpoint/endpoint.py
+++ b/apiron/endpoint/endpoint.py
@@ -3,7 +3,7 @@ import string
 import warnings
 from functools import partial, update_wrapper
 
-from apiron import ServiceCaller
+from apiron import client
 from apiron.exceptions import UnfulfilledParameterException
 
 
@@ -17,8 +17,8 @@ class Endpoint:
 
     def __get__(self, instance, owner):
         if not instance:
-            caller = partial(ServiceCaller.call, owner, self)
-            update_wrapper(caller, ServiceCaller.call)
+            caller = partial(client.call, owner, self)
+            update_wrapper(caller, client.call)
             return caller
         return self
 

--- a/apiron/endpoint/stub.py
+++ b/apiron/endpoint/stub.py
@@ -1,6 +1,6 @@
 from functools import partial, update_wrapper
 
-from apiron import ServiceCaller
+from apiron import client
 
 
 class StubEndpoint:
@@ -13,8 +13,8 @@ class StubEndpoint:
 
     def __get__(self, instance, owner):
         if not instance:
-            caller = partial(ServiceCaller.call, owner, self)
-            update_wrapper(caller, ServiceCaller.call)
+            caller = partial(client.call, owner, self)
+            update_wrapper(caller, client.call)
             return caller
         return self
 

--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -7,4 +7,4 @@ API reference
 
     services
     endpoints
-    service-caller
+    service-client

--- a/docs/api-reference/service-client.rst
+++ b/docs/api-reference/service-client.rst
@@ -1,5 +1,5 @@
 ##############
-Service caller
+Service client
 ##############
 
 .. automodule:: apiron.client

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,7 @@ Interacting with a service
 **************************
 
 Once your service definition is in place, you can interact with its endpoints
-using the :class:`ServiceCaller <apiron.client.ServiceCaller>`:
+in an SDK-like manner:
 
 .. code-block:: python
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,7 +1,6 @@
 ###############
-Getting Started
+Getting started
 ###############
-
 
 The goal of ``apiron`` is to get you up and running quickly,
 consuming a service with little initial configuration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,11 @@
-#######
+######
 apiron
-#######
+######
 
-A Python wrapper for interacting with RESTful APIs
+``apiron`` ("API" + "iron") is a Python wrapper for interacting with RESTful APIs
+
+.. TIP::
+    Read the :doc:`upgrade guide <upgrade-guide>` to make sure you're prepared for the latest version of apiron.
 
 Welcome to the documentation for ``apiron``!
 You can use this documentation to orient yourself to the codebase,
@@ -18,6 +21,7 @@ feel free to change it in a pull request!
 
     getting-started
     advanced-usage
+    upgrade-guide
     api-reference/index
 
 

--- a/docs/upgrade-guide.rst
+++ b/docs/upgrade-guide.rst
@@ -1,0 +1,84 @@
+#############
+Upgrade guide
+#############
+
+This document will guide you through upgrading from `apiron` 2.X versions to `apiron` 3.X.
+
+
+*********************************
+Replacing ``ServiceCaller`` usage
+*********************************
+
+As of version 2.3.0, instantiating a service class and passing it to ``ServiceCaller.call`` is no longer necessary.
+In 3.X, ``ServiceCaller`` has been removed altogether (though its behaviors are still in the :mod:`apiron.client` module).
+Replace calls to ``ServiceCaller.call`` with the more semantic ``SomeService.some_endpoint``:
+
+.. code-block:: python
+
+    # Before
+    from apiron.client import ServiceCaller
+    from apiron.service.base import Service
+    from apiron.endpoint import JsonEndpoint
+
+    class GitHub(Service):
+        domain = 'https://api.github.com'
+        user = JsonEndpoint(path='/users/{username}')
+        repo = JsonEndpoint(path='/repos/{org}/{repo}')
+
+    GITHUB = GitHub()
+
+    defunkt = ServiceCaller.call(GITHUB, GITHUB.user, path_kwargs={'username', 'defunkt'})
+
+
+    # After
+    from apiron.service.base import Service
+    from apiron.endpoint import JsonEndpoint
+
+    class GitHub(Service):
+        domain = 'https://api.github.com'
+        user = JsonEndpoint(path='/users/{username}')
+        repo = JsonEndpoint(path='/repos/{org}/{repo}')
+
+    defunkt = GitHub.user(path_kwargs={'username', 'defunkt'})
+
+
+*******************
+Simplifying imports
+*******************
+
+As of version 2.4.0, most classes are available as top-level imports from the ``apiron`` package:
+
+.. code-block:: python
+
+    # Before
+    from apiron.service.base import Service
+    from apiron.endpoint import JsonEndpoint
+
+    # After
+    from apiron import Service, JsonEndpoint
+
+
+**************************************
+Simplifying endpoint path placeholders
+**************************************
+
+As of version 2.5.0, ``path_kwargs`` is no longer necessary; just pass path fillers as additional keyword arguments:
+
+.. code-block:: python
+
+    # Before
+    defunkt = GitHub.user(path_kwargs={'username', 'defunkt'})
+
+    # After
+    defunkt = GitHub.user(username='defunkt')
+
+
+*******
+Summary
+*******
+
+Prepare for apiron 3.X by installing apiron 2.5+ and doing the following:
+
+- Replace ``ServiceCaller.call`` with the more direct ``SomeService.some_endpoint``
+- Import classes from ``apiron`` directly
+- Replace ``path_kwargs`` with direct keyword arguments

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -108,9 +108,7 @@ class TestEndpoint:
         request = mock.Mock()
         request.url = "http://host1.biz/foo/"
 
-        client.call(
-            instantiated_service, instantiated_service.foo, timeout_spec=mock_timeout, logger=mock_logger
-        )
+        client.call(instantiated_service, instantiated_service.foo, timeout_spec=mock_timeout, logger=mock_logger)
 
 
 class TestJsonEndpoint:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -98,12 +98,6 @@ class TestEndpoint:
         foo = apiron.JsonEndpoint(default_params={"foo": "bar"}, required_params={"foo"})
         assert {"foo": "bar"} == foo.get_merged_params()
 
-    @mock.patch("apiron.client.requests.Session.send")
-    def test_using_path_kwargs_produces_warning(self, mock_send, service):
-        service.foo = apiron.Endpoint(path="/foo/{one}")
-        with pytest.warns(RuntimeWarning, match="path_kwargs is no longer necessary"):
-            _ = service.foo(path_kwargs={"one": "bar"})
-
     @mock.patch("apiron.client.Timeout")
     @mock.patch("requests.Session", autospec=True)
     def test_legacy_endpoint_usage_with_instantiated_service(self, MockSession, mock_timeout, service):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 import apiron
-from apiron import ServiceCaller
+from apiron import client
 
 
 @pytest.fixture
@@ -114,7 +114,7 @@ class TestEndpoint:
         request = mock.Mock()
         request.url = "http://host1.biz/foo/"
 
-        ServiceCaller.call(
+        client.call(
             instantiated_service, instantiated_service.foo, timeout_spec=mock_timeout, logger=mock_logger
         )
 
@@ -215,4 +215,4 @@ class TestStubEndpoint:
 
     def test_call_with_initialized_service_works(self, service):
         service.stub = apiron.StubEndpoint(stub_response="foo")
-        assert ServiceCaller.call(service(), service().stub) == "foo"
+        assert client.call(service(), service().stub) == "foo"


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Cleans up the code to remove older ways of doing things, strongly encouraging users of `apiron` toward a single way of accomplishing service interactions.

**How does this change work?**
* Move `ServiceCaller` class' methods to the module level and remove the class
* Remove `path_kwargs` shims
