### PR TITLE
Add project URLs and revert to 3.7 as default Python in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ notifications:
   email: false
 
 python:
-  - '3.8-dev'
   - '3.7'
   - '3.6'
   - '3.5'
   - '3.4'
+  - '3.8-dev'
 
 # The "install" and "script" here are the default stage (test).
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,10 @@ license = MIT
 license_file = LICENSE
 long_description = file: README.md
 long_description_content_type = text/markdown
+project_urls =
+    Documentation=https://apiron.readthedocs.io
+    Source=https://github.com/ithaka/apiron
+    Tracker=https://github.com/ithaka/apiron/issues
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [x] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Add [project URLs](https://setuptools.readthedocs.io/en/latest/setuptools.html#metadata) that will show up nicely in PyPI and presumably other places

**How does this change work?**
A clear, detailed description of how this change addresses the issue.
This could be a bullet list if there are several moving parts.

**Additional context**
See Django's [setup.py](https://github.com/django/django/blob/master/setup.py#L110) and corresponding [PyPI display](https://pypi.org/project/Django/).
