### PR TITLE
Make raw response object accessible with new kwarg to call()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Ability to run linting and build docs using `tox`
+- Ability to access raw response object when making a call using `return_raw_response_object=True`.
+  Useful for accessing things like response cookies or headers.
 
 ### Changed
 - Moved implementation to `src/` directory for improved end-to-end testing with packaging.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,8 +182,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/': None,
-    'requests': ('http://docs.python-requests.org/en/master/', None),
+    'https://docs.python.org/3/': None,
+    'requests': ('https://2.python-requests.org/en/master/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/latest/', None),
 }
 

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -142,6 +142,7 @@ def call(
     timeout_spec=DEFAULT_TIMEOUT,
     logger=None,
     allow_redirects=True,
+    return_raw_response_object=False,
     **kwargs
 ):
     """
@@ -195,6 +196,9 @@ def call(
         (optional)
         Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection
         (default ``True``)
+    :param bool return_raw_response_object:
+        Whether to return a :class:`requests.Response` object or call :func:`format_response` on it first.
+        (Default ``False``)
     :param ``**kwargs``:
         Arguments to be formatted into the ``endpoint`` argument's ``path`` attribute
     :return:
@@ -252,4 +256,4 @@ def call(
     if encoding:
         response.encoding = encoding
 
-    return endpoint.format_response(response)
+    return response if return_raw_response_object else endpoint.format_response(response)


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Resolves #82 

**How does this change work?**
Adds a `return_raw_response_object` boolean to `apiron.client.call()` that returns the underlying `requests.Response` object.

**Additional context**
This change also fixes up some outdated intersphinx doc index links.
