### PR TITLE
Fix broken icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `apiron` helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 
-<img src="https://github.com/ithaka/apiron/raw/master/docs/_static/cast-iron-skillet.png" alt="Pie in a cast iron skillet" width="200">
+<img src="https://github.com/ithaka/apiron/raw/dev/docs/_static/cast-iron-skillet.png" alt="Pie in a cast iron skillet" width="200">
 
 Gathering data from multiple services has become a ubiquitous task for web application developers.
 The complexity can grow quickly:


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
`master` was no longer in use, so we deleted it. We updated most references to the branch, but missed this one that should show the icon on the project's homepage on GitHub.

**How does this change work?**
Update `master` reference to `dev`.