### PR TITLE
Bump pytest to more recent version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ lint =
     black
     pyflakes
 test =
-    pytest==4.2.0
+    pytest==4.6.6
     pytest-cov==2.6.1
 docs =
     importlib-metadata==0.18


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
The Travis CI build is [currently failing](https://travis-ci.org/ithaka/apiron/jobs/596618542). Per [this StackOverflow answer](https://stackoverflow.com/a/58189684/2077393), it's because pytest's dependency on attrs got a bit funky. Updating to a more recent pytest version should hopefully fix this.

**How does this change work?**
For now, I'm bumping this to the last version of pytest that supports Python 3.4; going to pytest 5+ would mean having the discussion about when to drop support for Python 3.4, which is good to have soon but may not be strictly required to fix this.
