### PR TITLE
Remove legacy Python version support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,9 +35,9 @@ To test `apiron`, check out the repository and:
 ```
 $ cd /path/to/apiron/
 $ pyenv virtualenv 3.7.3 apiron  # pick your favorite virtual environment tool
-$ pyenv local apiron:3.8-dev:3.7.3:3.6.8:3.5.7:3.4.3  # use any Python versions you want to test
-(apiron:3.8-dev:3.7.3:3.6.8:3.5.7:3.4.3) $ pip install -e .[test]
-(apiron:3.8-dev:3.7.3:3.6.8:3.5.7:3.4.3) $ pytest
+$ pyenv local apiron:3.8.0:3.7.3:3.6.8  # use any Python versions you want to test
+(apiron:3.8.0:3.7.3:3.6.8) $ pip install -e .[test]
+(apiron:3.8.0:3.7.3:3.6.8) $ pytest
 ```
 
 If you have `tox` installed, you may instead run `tox` to run the full matrix of tests across all Python versions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ notifications:
   email: false
 
 python:
+  - '3.8'
   - '3.7'
   - '3.6'
-  - '3.5'
-  - '3.4'
-  - '3.8-dev'
 
 # The "install" and "script" here are the default stage (test).
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Support for Python 3.4 and 3.5 has been removed based on official Python support timelines and usage statistics
+
 ## [4.2.0] - 2019-09-09
 ### Added
 - Ability to pass dict to `files` keyword argument for file-like-objects for multipart encoding upload

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/3/': None,
+    'python': ('https://docs.python.org/3/', None),
     'requests': ('https://requests.readthedocs.io/en/master/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/latest/', None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ CURRENT_YEAR = datetime.datetime.now().year
 ORG = 'Ithaka Harbors, Inc.'
 
 project = 'apiron'
-copyright = '{} {}'.format(CURRENT_YEAR, ORG)
+copyright = f'{CURRENT_YEAR} {ORG}'
 author = ORG
 
 RELEASE_VERSION = importlib_metadata.version('apiron')
@@ -54,7 +54,10 @@ extensions = [
     'sphinx.ext.coverage',
 ]
 
-autodoc_default_flags = ['members', 'show-inheritance']
+autodoc_default_options = {
+    'members': True,
+    'show-inheritance': True,
+}
 autodoc_mock_imports = []
 autoclass_content = 'both'
 
@@ -183,7 +186,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'https://docs.python.org/3/': None,
-    'requests': ('https://2.python-requests.org/en/master/', None),
+    'requests': ('https://requests.readthedocs.io/en/master/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/latest/', None),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py34', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -44,11 +42,11 @@ lint =
     black
     pyflakes
 test =
-    pytest==4.6.6
-    pytest-cov==2.6.1
+    pytest==5.2.2
+    pytest-cov==2.8.1
 docs =
-    importlib-metadata==0.18
-    sphinx==1.7.6
+    importlib-metadata==0.23
+    sphinx==2.2.1
     sphinx-autobuild==0.7.1
 
 ######################
@@ -73,7 +71,7 @@ addopts = -ra -q --strict --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py34,py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 extras = test

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -102,7 +102,7 @@ def build_request_object(
     headers=None,
     cookies=None,
     auth=None,
-    **kwargs
+    **kwargs,
 ):
     host = choose_host(service=service)
 
@@ -146,7 +146,7 @@ def call(
     logger=None,
     allow_redirects=True,
     return_raw_response_object=False,
-    **kwargs
+    **kwargs,
 ):
     """
     :param Service service:
@@ -236,10 +236,10 @@ def call(
         headers=headers,
         cookies=cookies,
         auth=auth,
-        **kwargs
+        **kwargs,
     )
 
-    logger.info("{method} {url}".format(method=method, url=request.url))
+    logger.info(f"{method} {request.url}")
 
     response = session.send(
         request,

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -107,7 +107,7 @@ class Endpoint:
     def _validate_path_placeholders(self, placeholder_names, path_kwargs):
         if any(path_kwarg not in placeholder_names for path_kwarg in path_kwargs):
             warnings.warn(
-                "An unknown path kwarg was supplied to {self}. kwargs supplied: {path_kwargs}",
+                f"An unknown path kwarg was supplied to {self}. kwargs supplied: {path_kwargs}",
                 RuntimeWarning,
                 stacklevel=6,
             )

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -41,9 +41,9 @@ class Endpoint:
 
         if "?" in path:
             warnings.warn(
-                "Endpoint path may contain query parameters. "
-                "Use the default_params or required_params attributes in the initialization of this endpoint, "
-                "or the params argument when calling the endpoint instead.".format(path),
+                f"Endpoint path ('{path}') may contain query parameters. "
+                f"Use the default_params or required_params attributes in the initialization of this endpoint, "
+                f"or the params argument when calling the endpoint instead.",
                 stacklevel=3,
             )
 
@@ -107,7 +107,7 @@ class Endpoint:
     def _validate_path_placeholders(self, placeholder_names, path_kwargs):
         if any(path_kwarg not in placeholder_names for path_kwarg in path_kwargs):
             warnings.warn(
-                "An unknown path kwarg was supplied to {}. kwargs supplied: {}".format(self, path_kwargs),
+                "An unknown path kwarg was supplied to {self}. kwargs supplied: {path_kwargs}",
                 RuntimeWarning,
                 stacklevel=6,
             )
@@ -117,8 +117,7 @@ class Endpoint:
 
         if empty_params:
             warnings.warn(
-                "The {path} endpoint "
-                "was called with empty parameters: {empty_params}".format(path=self.path, empty_params=empty_params),
+                f"The {self.path} endpoint " f"was called with empty parameters: {empty_params}",
                 RuntimeWarning,
                 stacklevel=6,
             )
@@ -161,4 +160,4 @@ class Endpoint:
         return self.path
 
     def __repr__(self):
-        return "{klass}(path='{path}')".format(klass=self.__class__.__name__, path=self.path)
+        return f"{self.__class__.__name__}(path='{self.path}')"

--- a/src/apiron/exceptions.py
+++ b/src/apiron/exceptions.py
@@ -4,13 +4,11 @@ class APIException(Exception):
 
 class NoHostsAvailableException(APIException):
     def __init__(self, service_name):
-        message = "No hosts available for service: {service_name}".format(service_name=service_name)
+        message = f"No hosts available for service: {service_name}"
         super().__init__(message)
 
 
 class UnfulfilledParameterException(APIException):
     def __init__(self, endpoint_path, unfulfilled_params):
-        message = "The {endpoint_path} endpoint was called without required parameters: {unfulfilled_params}".format(
-            endpoint_path=endpoint_path, unfulfilled_params=unfulfilled_params
-        )
+        message = f"The {endpoint_path} endpoint was called without required parameters: {unfulfilled_params}"
         super().__init__(message)

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -58,4 +58,4 @@ class Service(ServiceBase):
         return self.__class__.domain
 
     def __repr__(self):
-        return "{klass}(domain={domain})".format(klass=self.__class__.__name__, domain=self.__class__.domain)
+        return f"{self.__class__.__name__}(domain={self.__class__.domain})"

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -82,7 +82,7 @@ class TestEndpoint:
             assert "/foo/bar/" == foo.get_formatted_path(**path_kwargs)
 
     def test_query_parameter_in_path_generates_warning(self):
-        with pytest.warns(UserWarning, match="Endpoint path may contain query parameters"):
+        with pytest.warns(UserWarning, match=r"Endpoint path \('/\?foo=bar'\) may contain query parameters"):
             _ = apiron.Endpoint(path="/?foo=bar")
 
     def test_get_merged_params(self):


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [x] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Although it is important to maintain support for an older Python version with a demonstrated active user base, it's important to assess the landscape occasionally to make sure a package isn't languishing needlessly for what are only percieved support requirements.

Per [PyPI Stats](https://pypistats.org/packages/apiron) there are no regular users of `apiron` on Pythons 3.4 or 3.5. By removing support for these versions, we're able to benefit from new features like f-strings and type hinting along with newer versions of peripheral tooling like `pytest`.

Although this package doesn't have a particularly pressing need to upgrade, it's good to get into the practice of this kind of refresh.

**How does this change work?**

This removes all metadata and functionality indicating/exercising Python 3.4 and 3.5 support.

**Additional context**

This change also refreshes package versions for tests and docs and uses f-strings where valuable.
