### PR TITLE
Include tests in shipped package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.py


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
GNU Health is using apiron for their Orthanc integration, and as part of that effort the folks working on openSUSE [would like to include apiron](https://build.opensuse.org/request/show/752387) in their package manager repository so that it can be easily installed by their users.

The tests aren't currently included in the package we publish (an intentional decision originally made [here](https://github.com/ithaka/apiron/commit/2053ab2c11ff86f3a973844e1abf2811421dcbe6)), but they would act as a convenient verification step for the package after it's installed by the package manager.

**How does this change work?**
Create a `MANIFEST.in` file that includes all Python files in the `tests/` directory in the published package.