### PR TITLE
Trigger deployment on default Python in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
           skip_cleanup: true
           on:
               tags: true
-              python: '3.7'
+              python: '3.8'
 
         - &pypi  # Production PyPI
           provider: pypi


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [x] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
We moved Python 3.8 as the default in the Travis CI matrix but I neglected to update the deploy stage to match. This means the deploy stage gets skipped always.

**How does this change work?**
Use Python 3.8 as the match criteria for making a deployment, which runs on the default matrix Python (which is currently 3.8).
