### PR TITLE
#96 Enable specifying auth at the Service definition level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Ability to specify `proxies` for a `Service` definition so all calls to the service use the defined proxies
+- Ability to specify `auth` for a `Service` definition so all calls to the service use the defined authentication
 
 ## [5.0.0] - 2019-12-02
 ### Removed

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ lint =
 test =
     pytest==5.2.2
     pytest-cov==2.8.1
+    pytest-randomly==3.4.0
 docs =
     importlib-metadata==0.23
     sphinx==2.2.1
@@ -67,7 +68,7 @@ skip_covered = True
 
 [tool:pytest]
 testpaths = tests
-addopts = -ra -q --strict --cov
+addopts = -ra --strict --cov
 xfail_strict = True
 
 [tox:tox]

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,5 +86,5 @@ commands =
 [testenv:lint]
 extras = lint
 commands =
-    pyflakes src/apiron tests
-    black --check src/apiron tests
+    pyflakes {posargs:src tests}
+    black {posargs:--check src tests}

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -224,7 +224,7 @@ def call(
 
     method = method or endpoint.default_method
 
-    auth = session.auth or service.auth
+    auth = auth or session.auth or service.auth
 
     request = build_request_object(
         session,

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -224,6 +224,8 @@ def call(
 
     method = method or endpoint.default_method
 
+    auth=session.auth or service.auth
+    
     request = build_request_object(
         session,
         service,

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -224,7 +224,7 @@ def call(
 
     method = method or endpoint.default_method
 
-    auth=session.auth or service.auth
+    auth = session.auth or service.auth
 
     request = build_request_object(
         session,

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -225,7 +225,7 @@ def call(
     method = method or endpoint.default_method
 
     auth=session.auth or service.auth
-    
+
     request = build_request_object(
         session,
         service,

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -19,6 +19,7 @@ class ServiceMeta(type):
 
 class ServiceBase(metaclass=ServiceMeta):
     required_headers = {}
+    auth = ()
     proxies = {}
 
     @classmethod

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -3,7 +3,7 @@ import pytest
 from apiron import Endpoint, Service, ServiceBase
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def service():
     class SomeService(Service):
         domain = "http://foo.com"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -129,6 +129,7 @@ class TestClient:
         mock_session = MockSession()
         mock_session.send.return_value = mock_response
         mock_session.proxies = {}
+        mock_session.auth = ()
         mock_get_adapted_session.return_value = mock_session
 
         client.call(service, mock_endpoint, timeout_spec=mock_timeout, logger=mock_logger)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,6 @@ import io
 from unittest import mock
 
 import pytest
-from requests import Session
 
 from apiron import client, NoHostsAvailableException
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Resolves #96 

**How does this change work?**
By passing auth argument to underlying requests' methods
