### PR TITLE
Enable default raw response object preference in Endpoint definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Ability to specify `proxies` for a `Service` definition so all calls to the service use the defined proxies
+- Ability to specify `return_raw_response_object` at the endpoint level, overridden by any value specified at call time
 
 ## [5.0.0] - 2019-12-02
 ### Removed

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -145,7 +145,7 @@ def call(
     timeout_spec=DEFAULT_TIMEOUT,
     logger=None,
     allow_redirects=True,
-    return_raw_response_object=False,
+    return_raw_response_object=None,
     **kwargs,
 ):
     """
@@ -265,4 +265,11 @@ def call(
     if encoding:
         response.encoding = encoding
 
-    return response if return_raw_response_object else endpoint.format_response(response)
+    # Use the explicitly passed in option, if any
+    # Otherwise, use the endpoint's setting
+    if return_raw_response_object is None:
+        return_raw_response = endpoint.return_raw_response_object
+    else:
+        return_raw_response = return_raw_response_object
+
+    return response if return_raw_response else endpoint.format_response(response)

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -23,7 +23,14 @@ class Endpoint:
     def __call__(self):
         raise TypeError("Endpoints are only callable in conjunction with a Service class.")
 
-    def __init__(self, path="/", default_method="GET", default_params=None, required_params=None):
+    def __init__(
+        self,
+        path="/",
+        default_method="GET",
+        default_params=None,
+        required_params=None,
+        return_raw_response_object=False,
+    ):
         """
         :param str path:
             The URL path for this endpoint, without the protocol or domain
@@ -50,6 +57,7 @@ class Endpoint:
         self.path = path
         self.default_params = default_params or {}
         self.required_params = required_params or set()
+        self.return_raw_response_object = return_raw_response_object
 
     def format_response(self, response):
         """

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -43,6 +43,10 @@ class Endpoint:
         :param required_params:
             An iterable of required parameter names.
             Calling an endpoint without its required parameters raises an exception.
+        :param bool return_raw_response_object:
+            Whether to return a :class:`requests.Response` object or call :func:`format_response` on it first.
+            This can be overridden when calling the endpoint.
+            (Default ``False``)
         """
         self.default_method = default_method
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,7 +231,37 @@ class TestClient:
         session.send.return_value = mock_response
 
         response = client.call(
-            service, mock_endpoint, session=session, logger=mock.Mock(), return_raw_response_object=True
+            service, mock_endpoint, session=session, logger=mock.Mock(), return_raw_response_object=True,
+        )
+
+        assert response is mock_response
+
+    def test_call_when_raw_response_object_requested_on_endpoint(self, mock_response, mock_endpoint):
+        service = mock.Mock()
+        service.get_hosts.return_value = ["http://host1.biz"]
+        service.required_headers = {}
+
+        session = mock.Mock()
+        session.send.return_value = mock_response
+
+        mock_endpoint.return_raw_response_object = True
+
+        response = client.call(service, mock_endpoint, session=session, logger=mock.Mock())
+
+        assert response is mock_response
+
+    def test_return_raw_response_object_in_call_overrides_endpoint(self, mock_response, mock_endpoint):
+        service = mock.Mock()
+        service.get_hosts.return_value = ["http://host1.biz"]
+        service.required_headers = {}
+
+        session = mock.Mock()
+        session.send.return_value = mock_response
+
+        mock_endpoint.return_raw_response_object = False
+
+        response = client.call(
+            service, mock_endpoint, session=session, logger=mock.Mock(), return_raw_response_object=True,
         )
 
         assert response is mock_response


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

It's useful to specify that an Endpoint should always return the raw response object by default, with the ability to override as needed on a per-call basis (the way you can now).

**How does this change work?**

Adds a `return_raw_response_object` attribute to `Endpoint`'s constructor, which will act as the fallback value if one isn't specified in the call. This should retain current behavior and add the ability to specify this option for all calls to a particular endpoint:

```python
from apiron import Endpoint, Service


class HttpBin(Service):
    domain = 'https://httpbin.org'

    anything = Endpoint(path='/anything', return_raw_response_object=True)


HttpBin.anything()  # Returns raw response object
HttpBin.anything(return_raw_response_object=False)  # Returns formatted response
```

|Endpoint value|Call-time value|Computed value|
|---|---|---|
|`False` / Unspecified|`False` / Unspecified|`False`|
|`True`|Unspecified|`True`|
|`False` / Unspecified|`True`|`True`|
|`True`|`True`|`True`|
|`True`|`False`|`False`|