### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,14 @@ We squash commits when merging to `dev`, so it's okay if you have several commit
 That being said, please make sure your commit messages are clear so we can tell what's happening!
 
 
-## Commit messages
+## Commits
+
+### Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run checks on the code prior to a successful commit.
+Installing pre-commit and using its hooks can ease your development by uncovering issues earlier in the development life cycle.
+
+### Commit messages
 
 We don't currently have a strict commit message convention, but here are a few guidelines:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+####################################################
+# Checks about the pre-commit configuration itself #
+####################################################
+
+repos:
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply      # Ensures all defined hooks affect at least one file in the repo
+    -   id: check-useless-excludes # Ensures all defined excludes apply to at least one file in the repo
+
+###########################
+# General use / built-ins #
+###########################
+
+# Click through to this repository to see what other goodies are available
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: trailing-whitespace  # Removes trailing whitespace from lines in all file types
+    -   id: end-of-file-fixer    # Fixes last line of all file types
+    -   id: check-merge-conflict # Checks if you're about to commit a file that hasn't had conflicts resolved
+    -   id: no-commit-to-branch  # Checks if you're committing to a disallowed branch
+        args: [--branch, dev]
+    -   id: check-ast            # Checks that Python files are valid syntax
+
+##########
+# Python #
+##########
+
+# pyupgrade updates older syntax to newer syntax.
+# It's particularly handy for updating `.format()` calls to f-strings.
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.6.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+
+# Run black last on Python code so all changes from previous hooks are reformatted
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black
+        language_version: python3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to specify `auth` for a `Service` definition so all calls to the service use the defined authentication
 - Ability to specify `return_raw_response_object` at the endpoint level, overridden by any value specified at call time
 
+### Maintenance
+- Add [pre-commit](https://pre-commit.com/) configuration for earlier linting and formatting checks
+
 ## [5.0.0] - 2019-12-02
 ### Removed
 - Support for Python 3.4 and 3.5 has been removed based on official Python support timelines and usage statistics


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity
- [x] Maintainability improvement

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Finding linting and formatting issues after opening a pull request can be frustrating. Finding them early on makes it quicker and easier to address them.

**How does this change work?**

Add a [pre-commit](https://pre-commit.com/) configuration that runs `black` and some basic file checks on the code. This should provide space to expand to `pyflakes`/`pylint`/`mypy` later on.
