### PR TITLE
Add Python 3.9 and Python 3.10 support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,10 +41,10 @@ To test `apiron`, check out the repository and:
 
 ```
 $ cd /path/to/apiron/
-$ pyenv virtualenv 3.7.3 apiron  # pick your favorite virtual environment tool
-$ pyenv local apiron:3.8.0:3.7.3:3.6.8  # use any Python versions you want to test
-(apiron:3.8.0:3.7.3:3.6.8) $ pip install -e .[test]
-(apiron:3.8.0:3.7.3:3.6.8) $ pytest
+$ pyenv virtualenv 3.7.10 apiron  # pick your favorite virtual environment tool
+$ pyenv local apiron:3.10-dev:3.9.4:3.8.9:3.7.10:3.6.13  # use any Python versions you want to test
+(apiron:3.10-dev:3.9.4:3.8.9:3.7.10:3.6.13) $ pip install -e .[test]
+(apiron:3.10-dev:3.9.4:3.8.9:3.7.10:3.6.13) $ pytest
 ```
 
 If you have `tox` installed, you may instead run `tox` to run the full matrix of tests across all Python versions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ notifications:
   email: false
 
 python:
+  - '3.9'
   - '3.8'
   - '3.7'
   - '3.6'
+  - '3.10-dev'
 
 # The "install" and "script" here are the default stage (test).
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ notifications:
   email: false
 
 python:
-  - '3.9'
   - '3.8'
   - '3.7'
   - '3.6'
+  - '3.9'
   - '3.10-dev'
 
 # The "install" and "script" here are the default stage (test).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Testing matrix and trove classifiers for Python 3.9 and 3.10
+
 ## [5.1.0] - 2020-07-14
 ### Added
 - Ability to specify `proxies` for a `Service` definition so all calls to the service use the defined proxies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py36', 'py37', 'py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ addopts = -ra --strict --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39,py310
 
 [testenv]
 extras = test

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

We want to make sure the package continues to work on the latest versions of Python.

**How does this change work?**

* Add `py39,py310` to the tox configuration
* Add `3.9` and `3.10-dev` to the Travis CI testing matrix
* Add 3.9 and 3.10 to the trove classifiers

**Additional context**

We can't add Python 3.9 or 3.10 for black formatting yet because black does not yet have compatibility with those language versions.
