### PR TITLE
Remove Python 3.6 and 3.10 from test/pkg infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,11 @@ repos:
     rev: v2.7.4
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 
 # Run black last on Python code so all changes from previous hooks are reformatted
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b2
     hooks:
     -   id: black
         language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - '3.8'
   - '3.7'
   - '3.9'
-  - '3.10-dev'
 
 # The "install" and "script" here are the default stage (test).
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ notifications:
 python:
   - '3.8'
   - '3.7'
-  - '3.6'
   - '3.9'
   - '3.10-dev'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Testing matrix and trove classifiers for Python 3.9 and 3.10
+### Removed
+- Support for Python 3.6 has been removed due to its impending end of life and the desire to leverage features from 3.7
 
 ## [5.1.0] - 2020-07-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Testing matrix and trove classifiers for Python 3.9 and 3.10
+
 ### Removed
 - Support for Python 3.6 has been removed due to its impending end of life and the desire to leverage features from 3.7
+
+### Changed
+- Remove Python 3.10 testing and support for now, as Travis CI only has Python 3.10.0a5 which isn't compatible with recent pytest-randomly releases
 
 ## [5.1.0] - 2020-07-14
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     License :: OSI Approved :: MIT License
@@ -66,7 +65,7 @@ addopts = -ra --strict-markers --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39
 
 [testenv]
 deps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -39,19 +38,6 @@ where = src
 exclude =
     tests*
 
-[options.extras_require]
-lint =
-    black
-    pyflakes
-test =
-    pytest==5.2.2
-    pytest-cov==2.8.1
-    pytest-randomly==3.4.0
-docs =
-    importlib-metadata==0.23
-    sphinx==2.2.1
-    sphinx-autobuild==0.7.1
-
 ######################
 # Tool configuration #
 ######################
@@ -70,24 +56,32 @@ skip_covered = True
 
 [tool:pytest]
 testpaths = tests
-addopts = -ra --strict --cov
+addopts = -ra --strict-markers --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 [testenv]
-extras = test
+deps =
+    pytest>=6.0.0,<7
+    pytest-cov>=2.8.1,<3
+    pytest-randomly>=3.4.0,<4
 commands =
     pytest {posargs}
 
 [testenv:docs]
-extras = docs
+deps =
+    importlib-metadata==0.23
+    sphinx==2.2.1
+    sphinx-autobuild==0.7.1
 commands =
     sphinx-build -b html docs {envtmpdir}/docs
 
 [testenv:lint]
-extras = lint
+deps =
+    black
+    pyflakes
 commands =
     pyflakes {posargs:src tests}
     black {posargs:--check src tests}

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,12 @@ where = src
 exclude =
     tests*
 
+[options.extras_require]
+docs =
+    importlib-metadata==0.23
+    sphinx==2.2.1
+    sphinx-autobuild==0.7.1
+
 ######################
 # Tool configuration #
 ######################
@@ -71,10 +77,8 @@ commands =
     pytest {posargs}
 
 [testenv:docs]
-deps =
-    importlib-metadata==0.23
-    sphinx==2.2.1
-    sphinx-autobuild==0.7.1
+extras =
+    docs
 commands =
     sphinx-build -b html docs {envtmpdir}/docs
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Python 3.7 brought a number of notable improvements, including native type hinting support, dataclasses, module access customization, and reliable dictionary iteration order. Dropping support for Python 3.6 will allow us to take advantage of these features.

**How does this change work?**
Remove Python 3.6 from testing matrix, trove classifiers, syntax support lists, and so on.

**Additional context**
* I got rid of the `extras` approach in `setup.cfg` for everything but the docs (which is required by Read The Docs) and split the relevant dependencies out to their respective test environments—it's quite a bit cleaner.
* I loosened the pins on testing dependencies—it's probably good to keep them within a single major version, but not necessary to pin them to a single older release. Notably, the pytest version we were pinned to was failing in Python 3.10.
* Python 3.10, still in beta, updates the API for `importlib.metadata.entry_points`. `pytest-randomly` uses the new API if `sys.version_info` indicates Python 3.10. However, Travis CI only has Python 3.10.0a5, which didn't yet have the updated API, causing builds to fail on Python 3.10. This will settle out if we switch to GitHub Actions or when Travis refreshes their Python version offerings.