### PR TITLE
Lazily evaluate log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Use interpolation for logging messages to avoid wasted computation
+
 ## [6.0.0-post.1] - 2021-06-21
 ### Changed
 - Move from Travis CI to GitHub Actions for testing and publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.1] - 2021-10-12
 ### Changed
 - Use interpolation for logging messages to avoid wasted computation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apiron
-version = 6.0.0-post.1
+version = 6.0.1
 description = apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 author = Ithaka Harbors, Inc.
 author_email = opensource@ithaka.org

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -250,7 +250,7 @@ def call(
         **kwargs,
     )
 
-    logger.info(f"{method} {request.url}")
+    logger.info("%s %s", method, request.url)
 
     response = adapted_session.send(
         request,
@@ -261,11 +261,10 @@ def call(
     )
 
     logger.info(
-        "{status} {url}{history}".format(
-            status=response.status_code,
-            url=response.url,
-            history=" ({} redirect(s))".format(len(response.history)) if response.history else "",
-        )
+        "%d %s%s",
+        response.status_code,
+        response.url,
+        " ({} redirect(s))".format(len(response.history)) if response.history else "",
     )
 
     if managing_session:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -149,8 +149,8 @@ def test_call(
         proxies=service.proxies,
     )
 
-    mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
-    mock_logger.info.assert_any_call("200 http://host1.biz/foo/")
+    mock_logger.info.assert_any_call("%s %s", "GET", "http://host1.biz/foo/")
+    mock_logger.info.assert_any_call("%d %s%s", 200, "http://host1.biz/foo/", "")
 
     mock_endpoint.default_method = "POST"
     request.method = "POST"
@@ -165,8 +165,8 @@ def test_call(
         proxies=service.proxies,
     )
 
-    mock_logger.info.assert_any_call("GET http://host1.biz/foo/")
-    mock_logger.info.assert_any_call("200 http://host1.biz/foo/")
+    mock_logger.info.assert_any_call("%s %s", "GET", "http://host1.biz/foo/")
+    mock_logger.info.assert_any_call("%d %s%s", 200, "http://host1.biz/foo/", "")
 
     request.method = "PUT"
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Logging messages only need to be evaluated when the log level for a running application is set such that a given log message will actually be emitted. By formatting strings directly using any of the formatting options (f-string, `.format()`, or `%`), potentially wasted CPU and memory are consumed.

Changing to interpolation also allows tooling to better aggregate logs that come from the same lines, even when the values interpolated into them differ.

**How does this change work?**

Switch to log interpolation for the logs present.