### PR TITLE
Allow downstream type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2021-12-21
+### Added
+- Add `py.typed` file so mypy can check against package types in downstream applications
+
 ## [6.0.1] - 2021-10-12
 ### Changed
 - Use interpolation for logging messages to avoid wasted computation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.0] - 2021-12-21
+## [6.2.0] - 2021-12-22
 ### Added
 - Add `py.typed` file so mypy can check against package types in downstream applications
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.0] - 2021-12-22
+## [6.1.0] - 2021-12-22
 ### Added
 - Add `py.typed` file so mypy can check against package types in downstream applications
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include tests *.py
+recursive-include src py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ exclude =
 [options.extras_require]
 docs =
     importlib-metadata>=4.5.0,<5
-    sphinx>=3.0,<4
+    sphinx>=4.3.2,<5
     sphinx-autodoc-typehints>=1.12.0,<2
     sphinx-autobuild>=2021.3.14
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apiron
-version = 6.0.1
+version = 6.1.0
 description = apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 author = Ithaka Harbors, Inc.
 author_email = opensource@ithaka.org


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**

This package has type hints, which are checked for self-consistency. Downstream packages may have type hints, also checked for self-consistency. Without a `py.typed` file, downstream applications can't check for consistency against this package.

**How does this change work?**

Create a `py.typed` file and include it via `MANIFEST.in`.

**Additional context**

Updated `sphinx` because the docs were failing to build against Python 3.10.
