### PR TITLE
Update copyright year in README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018-2021 Ithaka Harbors, Inc.
+Copyright 2018-2022 Ithaka Harbors, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction,

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Please read our [contribution guidelines](./.github/CONTRIBUTING.md) before gett
 This package is available under the MIT license.
 For more information, [view the full license and copyright notice](./LICENSE).
 
-Copyright 2018-2021 Ithaka Harbors, Inc.
+Copyright 2018-2022 Ithaka Harbors, Inc.


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity
- [x] Legal requirement

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Our current copyright statement would indicate our copyright expired in 2021.

**How does this change work?**

This [may not be necessary](https://hynek.me/til/copyright-years/), but I'm conservatively updating the year in the copyright statements instead of removing them, for now.
