### PR TITLE
Create paramspec for `Endpoint.__get__`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ commands =
 [testenv:typecheck]
 deps =
     mypy
+    typing_extensions
     types-requests
 commands =
     mypy --ignore-missing-imports {posargs:src tests}

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 # Mypy doesn't fully support PEP 612, hence the type ignore.
 # Ref: https://github.com/python/mypy/issues/8645
-def __create_caller(
+def _create_caller(
     call_fn: Callable["Concatenate[Service, Endpoint, P]", "R"],  # type: ignore
     instance: Any,
     owner: Any,
@@ -41,7 +41,7 @@ class Endpoint:
     """
 
     def __get__(self, instance, owner):
-        caller = __create_caller(client.call, owner, self)
+        caller = _create_caller(client.call, owner, self)
         update_wrapper(caller, client.call)
         return caller
 

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Concatenate, ParamSpec
 
+    from apiron.service import Service
+
     P = ParamSpec("P")
     R = TypeVar("R")
 
@@ -18,13 +20,12 @@ import requests
 
 from apiron import client
 from apiron.exceptions import UnfulfilledParameterException
-from apiron.service import Service
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_caller(
+def __create_caller(
     call_fn: Callable["Concatenate[Service, Endpoint, P]", "R"],
     instance: Any,
     owner: Any,
@@ -38,7 +39,7 @@ class Endpoint:
     """
 
     def __get__(self, instance, owner):
-        caller = create_caller(client.call, owner, self)
+        caller = __create_caller(client.call, owner, self)
         update_wrapper(caller, client.call)
         return caller
 

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -25,8 +25,10 @@ from apiron.exceptions import UnfulfilledParameterException
 LOGGER = logging.getLogger(__name__)
 
 
+# Mypy doesn't fully support PEP 612, hence the type ignore.
+# Ref: https://github.com/python/mypy/issues/8645
 def __create_caller(
-    call_fn: Callable["Concatenate[Service, Endpoint, P]", "R"],
+    call_fn: Callable["Concatenate[Service, Endpoint, P]", "R"],  # type: ignore
     instance: Any,
     owner: Any,
 ) -> Callable["P", "R"]:

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import string
 import sys

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -1,11 +1,15 @@
 import logging
 import string
+import sys
 import warnings
 from functools import partial, update_wrapper
 from typing import Any, Callable, Dict, Iterable, List, TypeVar, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec
+    if sys.version_info >= (3, 10):
+        from typing import Concatenate, ParamSpec
+    else:
+        from typing_extensions import Concatenate, ParamSpec
 
     P = ParamSpec("P")
     R = TypeVar("R")

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -29,7 +29,7 @@ def __create_caller(
     call_fn: Callable["Concatenate[Service, Endpoint, P]", "R"],
     instance: Any,
     owner: Any,
-) -> Callable[P, R]:
+) -> Callable["P", "R"]:
     return partial(call_fn, instance, owner)
 
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite passing?
- [ ] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**
Resolves #54

**How does this change work?**
PEP 612 added `ParamSpec` and `Concatenate` builtins to the typing module. That should allow you to type check `Endpoint.__get__`.

`from __future__ import annotations` is added because `Callable` necessarily expects a list of items as the first argument in Python 3.8 and below, causing a runtime validation crash. The future import treats annotations as strings, so it doesn't crash at runtime. 

Mypy currently doesn't understand `Concatenate`, and will complain. But pyright type checks it properly, and both vscode and PyCharm should show the correct annotations and autocomplete:

![image](https://user-images.githubusercontent.com/43412083/153253416-88bde9ee-3241-486c-8ee2-1864708efb29.png)
