### PR TITLE
Run Actions on pull requests from public forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Checks
-on: [push]
+on: [pull_request, push]
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Checks
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
 
 jobs:
   lint:


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

GitHub Actions triggered only by `push` don't trigger workflows from public forks. We're just noticing this now because contributors since switching to Actions have had write access to the repository and opened pull requests directly from branches.

**How does this change work?**

Also trigger Actions workflow on the `pull_request` event.