### PR TITLE
Implement instantiated services option. Resolve #119

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -113,3 +113,40 @@ This is useful for workflows where cookies or other information need to persist 
 It's often more useful in logs to know which module initiated the code doing the logging.
 ``apiron`` allows for an existing logger object to be passed to an endpoint call using the ``logger`` argument
 so that logs will indicate the caller module rather than :mod:`apiron.client`.
+
+
+**********************
+Instantiated endpoints
+**********************
+
+While the other documented usage patterns implement the singleton pattern, you may wish to use instantiated
+services for reasons such as those mentioned `in this issue <https://github.com/ithaka/apiron/issues/119>`_.
+
+This feature can be enabled by setting ``APIRON_INSTANTIATED_SERVICES=1`` either in the shell in which your
+program runs or early in the entrypoint to your program, prior to the evaluation of your service classes.
+
+Endpoints should then be called on instances of ``Service`` subclasses, rather than the class itself:
+
+As an additional benefit, arguments passed into the constructor will be passed through to the endpoint as arguments
+to the caller that forms the request. See ``aprion.client.call`` for all the available options.
+
+.. code-block:: python
+
+    import os
+
+    import requests
+
+    from apiron import JsonEndpoint, Service
+
+    os.environ['APIRON_INSTANTIATED_SERVICES'] = "1"
+
+
+    class GitHub(Service):
+        domain = 'https://api.github.com'
+        user = JsonEndpoint(path='/users/{username}')
+        repo = JsonEndpoint(path='/repos/{org}/{repo}')
+
+
+    service = GitHub(session=requests.Session())
+    response = service.user(username='defunkt')
+    print(response)

--- a/src/apiron/endpoint/stub.py
+++ b/src/apiron/endpoint/stub.py
@@ -11,8 +11,8 @@ class StubEndpoint(Endpoint):
     before the endpoint is complete.
     """
 
-    def __get__(self, instance, owner):
-        return self.stub_response
+    def __call__(self, service, *args, **kwargs):
+        return self.stub_response(*args, **kwargs)
 
     def __init__(self, stub_response: Optional[Any] = None, **kwargs):
         """

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -1,16 +1,33 @@
+import os
+import types
 from typing import Any, Dict, List, Set
 
 from apiron import Endpoint
 
 
 class ServiceMeta(type):
+    _instance: "ServiceBase"
+
     @property
     def required_headers(cls) -> Dict[str, str]:
         return cls().required_headers
 
-    @property
-    def endpoints(cls) -> Set[Endpoint]:
-        return {attr for attr_name, attr in cls.__dict__.items() if isinstance(attr, Endpoint)}
+    @classmethod
+    def _instantiated_services(cls) -> bool:
+        setting_variable = "APIRON_INSTANTIATED_SERVICES"
+        false_values = ["0", "false"]
+        true_values = ["1", "true"]
+        environment_setting = os.getenv(setting_variable, "false").lower()
+        if environment_setting in false_values:
+            return False
+        elif environment_setting in true_values:
+            return True
+
+        setting_values = false_values + true_values
+        raise ValueError(
+            f'Invalid {setting_variable}, "{environment_setting}"\n',
+            f"{setting_variable} must be one of {setting_values}\n",
+        )
 
     def __str__(cls) -> str:
         return str(cls())
@@ -18,14 +35,48 @@ class ServiceMeta(type):
     def __repr__(cls) -> str:
         return repr(cls())
 
+    def __new__(cls, name, bases, namespace, **kwargs):
+        klass = super().__new__(cls, name, bases, namespace, **kwargs)
+
+        # Behave as a normal class if instantiated services are enabled or if
+        # this is an apiron base class.
+        if cls._instantiated_services() or klass.__module__.split(".")[:2] == ["apiron", "service"]:
+            return klass
+
+        # Singleton class.
+        if not hasattr(klass, "_instance"):
+            klass._instance = klass()
+
+        # Mask declared Endpoints with bound instance methods. (singleton)
+        for k, v in namespace.items():
+            if isinstance(v, Endpoint):
+                setattr(klass, k, types.MethodType(v, klass._instance))
+
+        return klass._instance
+
 
 class ServiceBase(metaclass=ServiceMeta):
     required_headers: Dict[str, Any] = {}
     auth = ()
     proxies: Dict[str, str] = {}
+    domain: str
 
-    @classmethod
-    def get_hosts(cls) -> List[str]:
+    def __setattr__(self, name, value):
+        """Transform assigned Endpoints into bound instance methods."""
+        if isinstance(value, Endpoint):
+            value = types.MethodType(value, self)
+        super().__setattr__(name, value)
+
+    @property
+    def endpoints(self) -> Set[Endpoint]:
+        endpoints = set()
+        for attr in self.__dict__.values():
+            func = getattr(attr, "__func__", None)
+            if isinstance(func, Endpoint):
+                endpoints.add(func)
+        return endpoints
+
+    def get_hosts(self) -> List[str]:
         """
         The fully-qualified hostnames that correspond to this service.
         These are often determined by asking a load balancer or service discovery mechanism.
@@ -35,7 +86,7 @@ class ServiceBase(metaclass=ServiceMeta):
         :rtype:
             list
         """
-        return []
+        return [self.domain]
 
 
 class Service(ServiceBase):
@@ -45,23 +96,21 @@ class Service(ServiceBase):
     A service has a domain off of which one or more endpoints stem.
     """
 
-    domain: str
+    @property
+    def domain(self):
+        return self._domain if self._domain else self.__class__.domain
 
-    @classmethod
-    def get_hosts(cls) -> List[str]:
-        """
-        The fully-qualified hostnames that correspond to this service.
-        These are often determined by asking a load balancer or service discovery mechanism.
+    def __init__(self, domain=None, **kwargs):
+        self._domain = domain
+        self._kwargs = kwargs
 
-        :return:
-            The hostname strings corresponding to this service
-        :rtype:
-            list
-        """
-        return [cls.domain]
+        # Mask declared Endpoints with bound instance methods. (instantiated)
+        for name, attr in self.__class__.__dict__.items():
+            if isinstance(attr, Endpoint):
+                setattr(self, name, types.MethodType(attr, self))
 
     def __str__(self) -> str:
-        return self.__class__.domain
+        return self.domain
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(domain={self.__class__.domain})"
+        return f"{self.__class__.__name__}(domain={self.domain})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+
+import apiron
+
+
+def instantiated_service(returntype="instance"):
+    os.environ["APIRON_INSTANTIATED_SERVICES"] = "1"
+
+    class SomeService(apiron.Service):
+        pass
+
+    if returntype == "instance":
+        return SomeService(domain="http://foo.com")
+    elif returntype == "class":
+        return SomeService
+
+    raise ValueError('Expected "returntype" value to be "instance" or "class".')
+
+
+def singleton_service():
+    os.environ["APIRON_INSTANTIATED_SERVICES"] = "0"
+
+    class SomeService(apiron.Service):
+        domain = "http://foo.com"
+
+    return SomeService
+
+
+@pytest.fixture(scope="function", params=["singleton", "instance"])
+def service(request):
+    if request.param == "singleton":
+        yield singleton_service()
+    elif request.param == "instance":
+        yield instantiated_service()
+    else:
+        raise ValueError(f'unknown service type "{request.param}"')

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -1,20 +1,7 @@
-import pytest
-
-from apiron import Endpoint, Service, ServiceBase
-
-
-@pytest.fixture
-def service():
-    class SomeService(Service):
-        domain = "http://foo.com"
-
-    return SomeService
+from apiron import Endpoint
 
 
 class TestServiceBase:
-    def test_get_hosts_returns_empty_list_by_default(self):
-        assert [] == ServiceBase.get_hosts()
-
     def test_required_headers_returns_empty_dict_by_default(self, service):
         assert {} == service.required_headers
 

--- a/tests/service/test_instantiated.py
+++ b/tests/service/test_instantiated.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+
+from apiron.service.base import ServiceMeta
+
+from .. import conftest
+
+
+class TestInstantiatedServices:
+    @pytest.mark.parametrize("value,result", [("0", False), ("false", False), ("1", True), ("true", True)])
+    def test_instantiated_services_variable_true(self, value, result):
+        os.environ["APIRON_INSTANTIATED_SERVICES"] = value
+
+        assert ServiceMeta._instantiated_services() is result
+
+    @pytest.mark.parametrize("value", ["", "YES"])
+    def test_instantiated_services_variable_other(self, value):
+        os.environ["APIRON_INSTANTIATED_SERVICES"] = value
+
+        with pytest.raises(ValueError, match="Invalid"):
+            ServiceMeta._instantiated_services()
+
+    def test_singleton_constructor_arguments(self):
+        """Singleton services do not accept arguments."""
+        service = conftest.singleton_service()
+
+        with pytest.raises(TypeError, match="object is not callable"):
+            service(foo="bar")
+
+    def test_instantiated_services_constructor_arguments(self):
+        """Instantiated services accept arguments."""
+        service = conftest.instantiated_service(returntype="class")
+
+        service(foo="bar")

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -7,14 +7,6 @@ import apiron
 
 
 @pytest.fixture
-def service():
-    class SomeService(apiron.Service):
-        domain = "http://foo.com"
-
-    return SomeService
-
-
-@pytest.fixture
 def stub_function():
     def stub_response(**kwargs):
         if kwargs.get("params") and kwargs["params"].get("param_key") == "param_value":
@@ -28,12 +20,12 @@ def stub_function():
 class TestEndpoint:
     def test_call(self, service):
         service.foo = apiron.Endpoint()
-        service.foo()
+        service.foo()  # type: ignore
 
     def test_call_without_service_raises_exception(self):
         foo = apiron.Endpoint()
         with pytest.raises(TypeError):
-            foo()
+            foo()  # type: ignore
 
     def test_default_attributes_from_constructor(self):
         foo = apiron.Endpoint()
@@ -163,11 +155,11 @@ class TestStreamingEndpoint:
 class TestStubEndpoint:
     def test_stub_default_response(self, service):
         service.stub_endpoint = apiron.StubEndpoint()
-        assert service.stub_endpoint() == {"response": "StubEndpoint(path='/')"}
+        assert service.stub_endpoint() == {"response": "StubEndpoint(path='/')"}  # type: ignore
 
     def test_call_static(self, service):
         service.stub_endpoint = apiron.StubEndpoint(stub_response="stub response")
-        assert service.stub_endpoint() == "stub response"
+        assert service.stub_endpoint() == "stub response"  # type: ignore
 
     @pytest.mark.parametrize(
         "test_call_kwargs,expected_response",
@@ -181,7 +173,7 @@ class TestStubEndpoint:
     def test_call_without_service_raises_exception(self):
         stub_endpoint = apiron.StubEndpoint(stub_response="foo")
         with pytest.raises(TypeError):
-            stub_endpoint()
+            stub_endpoint()  # type: ignore
 
     def test_str_method(self):
         foo = apiron.StubEndpoint(path="/bar/baz")


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [X] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [X] No

**Is the:**
- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite passing?
- [X] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**
Resolve #119. While I think the singleton pattern should be deprecated, put under a feature flag, and discouraged, the first step is probably to give instantiated services some field experience as an optional feature.

**How does this change work?**
This introduces an option to enable instantiated services while maintaining backwards compatibility with the singleton pattern. See the section I added to the docs and the examples I added to https://github.com/ryneeverett/quasi-apiron starting in `apiron_instantiated_example_*.py`, which are adaptions of my previous examples which work with this branch.

The implementation works in a backwards compatible way by using meta-programming to store and return a single instance of each service class when instantiated services are not enabled. This enables the rest of the code base to work with services as instantiated classes, regardless of whether this feature is enabled.

**Additional context**

1. It might not be viable to support both the singleton and instantiated services model indefinitely. If there's no possibility of eventually making a transition away from the singleton model, it might make more sense to tell me to fork. I'd hate to go that route but it might be better than making the meta-programming more complicated. On the other hand, I find that the endpoint implementation is a lot more straightforward with this approach.
2. It might make sense to address the untidy mixing of kwargs (#125) prior to #119, because this branch does somewhat exacerbate the problem.
3. You might want to take a particular look at what I did with `ServiceBase.get_hosts` (and my deletion of `TestServiceBase.test_get_hosts_returns_empty_list_by_default`). I don't really understand the service discovery feature which I believe is the main point of that method so I'm liable to have broken something.