### PR TITLE
Speed up unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0-post.2] - 2023-06-14
+### Changed
+- Use `package` and `wheel_build_env` to speed up tests as this is a pure Python package. See the [tox docs](https://tox.wiki/en/latest/upgrading.html#universal-wheels) for more detail.
+
 ## [7.1.0-post.1] - 2023-04-24
 ### Changed
 - Use PyPI trusted publishing instead of manual token authentication

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apiron
-version = 7.1.0-post.1
+version = 7.1.0-post.2
 description = apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 author = Ithaka Harbors, Inc.
 author_email = opensource@ithaka.org
@@ -87,6 +87,8 @@ envlist = py37,py38,py39,py310,py311
 isolated_build = True
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 deps =
     pytest>=6.0.0,<7
     pytest-cov>=2.8.1,<3


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

tox can perform less work when a Python package is a universal wheel (pure Python, mostly).

**How does this change work?**

Add `package` and `wheel_build_env` to `setup.cfg[testenv]` per [the docs](https://tox.wiki/en/latest/upgrading.html#universal-wheels) (and thanks be to @hynek for [the visibility](https://twitter.com/hynek/status/1668167642388082688)).

**Additional context**

On my machine, running tests against just three of the environments, this change speeds up the total run time of the tests from about 8.8s (across three runs) to 3.0s (across three runs).

On GitHub Actions it appears to speed up tests from 12-14s to 9-12s, though this is generally less of a bottlenecked phase.
