### PR TITLE
Fix publishing of PyPI artifacts to GitHub release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.1.0-post.2] - 2023-06-14
+## [7.1.0-post.3] - 2023-06-20
+### Fixed
+- Update permissions in publishing workflow to allow publishing of files to GitHub releases
+
+## [7.1.0-post.2] - 2023-06-20
 ### Changed
 - Use `package` and `wheel_build_env` to speed up tests as this is a pure Python package. See the [tox docs](https://tox.wiki/en/latest/upgrading.html#universal-wheels) for more detail.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apiron
-version = 7.1.0-post.2
+version = 7.1.0-post.3
 description = apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 author = Ithaka Harbors, Inc.
 author_email = opensource@ithaka.org


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Publishing to PyPI currently works, but the workflow fails when the job attempts to add the source code and wheel file artifacts to the GitHub release afterward. This seems like a permissions issue and the fix here has been suggested in [this thread](https://github.com/softprops/action-gh-release/issues/232) in the action's repo.

**How does this change work?**

Add `contents: write` to the job permissions.
