### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,17 +37,8 @@ Nonetheless, when fixing a bug it is helpful to us that you add a failing test t
 If adding a new feature, it should also be thoroughly tested.
 This allows for easier refactoring to prove that nothing broke in transit!
 
-To test `apiron`, check out the repository and:
-
-```
-$ cd /path/to/apiron/
-$ pyenv virtualenv 3.7.10 apiron  # pick your favorite virtual environment tool
-$ pyenv local apiron:3.10-dev:3.9.4:3.8.9:3.7.10  # use any Python versions you want to test
-(apiron:3.10-dev:3.9.4:3.8.9:3.7.10) $ pip install -e .[test]
-(apiron:3.10-dev:3.9.4:3.8.9:3.7.10) $ pytest
-```
-
-If you have `tox` installed, you may instead run `tox` to run the full matrix of tests across all Python versions.
+To test `apiron`, check out the repository and ensure the Python versions you would like to test are available on your `$PATH` as versioned executables like `python3.10`.
+Then, use `tox` to run the tests.
 
 
 ## Code formatting

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,6 @@ jobs:
             toxenv: 'py39'
           - version: '3.8'
             toxenv: 'py38'
-          - version: '3.7'
-            toxenv: 'py37'
     steps:
       - uses: actions/checkout@v3
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,12 @@ sphinx:
 
 formats: all
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: "3.11"
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.8
+  version: 3.11
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.11
+  version: "3.11"
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Updated to simpler typing syntax for optional arguments and iterable types using `pyupgrade`
+- Reformatted files constrained to Python 3.8+ syntax using `black`
+- Updated documentation to prefer `tox` usage
+- Updated documentation dependencies and removed upper bounds on their versions
+
+### Removed
+- apiron no longer supports Python 3.7, which reached end of life on 2023-06-27
+
 ## [7.1.0-post.3] - 2023-06-20
 ### Fixed
 - Update permissions in publishing workflow to allow publishing of files to GitHub releases

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import datetime
-import importlib_metadata
+import importlib.metadata
 import os
 import sys
 
@@ -28,7 +28,7 @@ project = "apiron"
 copyright = f"2018–{CURRENT_YEAR} {ORG}"
 author = ORG
 
-RELEASE_VERSION = importlib_metadata.version("apiron")
+RELEASE_VERSION = importlib.metadata.version("apiron")
 
 # The short X.Y version
 version = RELEASE_VERSION
@@ -77,7 +77,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/docs-meta.rst
+++ b/docs/docs-meta.rst
@@ -11,19 +11,33 @@ Developing
 If you have `tox` installed, you may build these docs by running `tox -e docs`.
 Otherwise, you can follow the instructions below to manually install dependencies and build the docs.
 
+Automated
+=========
+
+You can use the ``docs`` environment for ``tox`` to build the documentation.
+With ``tox`` installed, run ``tox -e docs`` to build the HTML documentation.
+After the documentation is built, you can serve the build directory, which will be located at ``.tox/docs/tmp/docs``.
+
+Manual
+======
+
+You can also manage the documentation manually if you want more control.
+
 Installation
-============
+------------
+
+Use your favorite method to create a virtual environment and install the package with its extras for documentation:
 
 .. code-block:: shell
 
     $ cd /path/to/apiron/
-    $ pyenv virtualenv 3.7.0 apiron  # pick your favorite virtual environment tool
+    $ pyenv virtualenv 3.8.0 apiron  # pick your favorite virtual environment tool
     $ pyenv local apiron
     (apiron) $ pip install -e .[docs]
 
 
 Building
-========
+--------
 
 You can build or rebuild the static documentation using ``make``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apiron
-version = 7.1.0-post.3
+version = 8.0.0
 description = apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP.
 author = Ithaka Harbors, Inc.
 author_email = opensource@ithaka.org
@@ -19,7 +19,6 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -43,9 +42,8 @@ exclude =
 
 [options.extras_require]
 docs =
-    importlib-metadata>=4.5.0,<5
-    sphinx>=4.3.2,<5
-    sphinx-autodoc-typehints>=1.12.0,<2
+    sphinx>=7.2.2
+    sphinx-autodoc-typehints>=1.24.0
     sphinx-autobuild>=2021.3.14
 
 ######################
@@ -53,7 +51,7 @@ docs =
 ######################
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_unused_configs = True
 show_error_context = True
 pretty = True
@@ -83,16 +81,16 @@ addopts = -ra --strict-markers --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 isolated_build = True
 
 [testenv]
 package = wheel
 wheel_build_env = .pkg
 deps =
-    pytest>=6.0.0,<7
-    pytest-cov>=2.8.1,<3
-    pytest-randomly>=3.4.0,<4
+    pytest>=7.0.0
+    pytest-cov>=4.1.0
+    pytest-randomly>=3.15.0
 commands =
     pytest {posargs}
 

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import collections
 import logging
 import random
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from urllib import parse
 
 import requests
@@ -69,7 +69,7 @@ def _adapt_session(session: requests.Session, adapter: requests.adapters.HTTPAda
     return session
 
 
-def _get_required_headers(service: apiron.Service, endpoint: apiron.Endpoint) -> Dict[str, str]:
+def _get_required_headers(service: apiron.Service, endpoint: apiron.Endpoint) -> dict[str, str]:
     """
     :param Service service:
         The service being called
@@ -97,14 +97,14 @@ def _build_request_object(
     session: requests.Session,
     service: apiron.Service,
     endpoint: apiron.Endpoint,
-    method: Optional[str] = None,
-    params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None,
-    files: Optional[Dict[str, str]] = None,
-    json: Optional[Dict[str, Any]] = None,
-    headers: Optional[Dict[str, Any]] = None,
-    cookies: Optional[Dict[str, Any]] = None,
-    auth: Optional[Any] = None,
+    method: str | None = None,
+    params: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
+    cookies: dict[str, Any] | None = None,
+    auth: Any | None = None,
     **kwargs,
 ):
     host = _choose_host(service=service)
@@ -131,38 +131,38 @@ def _build_request_object(
     return session.prepare_request(request)
 
 
-def _get_guaranteed_session(session: Optional[requests.Session]) -> requests.Session:
+def _get_guaranteed_session(session: requests.Session | None) -> requests.Session:
     if session:
         return session
     return requests.Session()
 
 
-def _get_retry_spec(endpoint: apiron.Endpoint, retry_spec: Optional[retry.Retry] = None) -> retry.Retry:
+def _get_retry_spec(endpoint: apiron.Endpoint, retry_spec: retry.Retry | None = None) -> retry.Retry:
     return retry_spec or endpoint.retry_spec or DEFAULT_RETRY
 
 
-def _get_timeout_spec(endpoint: apiron.Endpoint, timeout_spec: Optional[Timeout] = None) -> Timeout:
+def _get_timeout_spec(endpoint: apiron.Endpoint, timeout_spec: Timeout | None = None) -> Timeout:
     return timeout_spec or endpoint.timeout_spec or DEFAULT_TIMEOUT
 
 
 def call(
     service: apiron.Service,
     endpoint: apiron.Endpoint,
-    method: Optional[str] = None,
-    session: Optional[requests.Session] = None,
-    params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None,
-    files: Optional[Dict[str, str]] = None,
-    json: Optional[Dict[str, Any]] = None,
-    headers: Optional[Dict[str, Any]] = None,
-    cookies: Optional[Dict[str, Any]] = None,
-    auth: Optional[Any] = None,
-    encoding: Optional[str] = None,
-    retry_spec: Optional[retry.Retry] = None,
-    timeout_spec: Optional[Timeout] = None,
-    logger: Optional[logging.Logger] = None,
+    method: str | None = None,
+    session: requests.Session | None = None,
+    params: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+    files: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
+    cookies: dict[str, Any] | None = None,
+    auth: Any | None = None,
+    encoding: str | None = None,
+    retry_spec: retry.Retry | None = None,
+    timeout_spec: Timeout | None = None,
+    logger: logging.Logger | None = None,
     allow_redirects: bool = True,
-    return_raw_response_object: Optional[bool] = None,
+    return_raw_response_object: bool | None = None,
     **kwargs,
 ):
     """
@@ -277,7 +277,7 @@ def call(
         "%d %s%s",
         response.status_code,
         response.url,
-        " ({} redirect(s))".format(len(response.history)) if response.history else "",
+        f" ({len(response.history)} redirect(s))" if response.history else "",
     )
 
     if managing_session:


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [x] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Python 3.7 support ended on 2023-06-27.

**How does this change work?**

- Updated to simpler typing syntax for optional arguments and iterable types using `pyupgrade`
- Reformatted files constrained to Python 3.8+ syntax using `black`
- Updated documentation to prefer `tox` usage
- Updated documentation dependencies and removed upper bounds on their versions