### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
     strategy:
       matrix:
         python:
+          - version: '3.12'
+            toxenv: 'py312'
           - version: '3.11'
             toxenv: 'py311'
           - version: '3.10'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reformatted files constrained to Python 3.8+ syntax using `black`
 - Updated documentation to prefer `tox` usage
 - Updated documentation dependencies and removed upper bounds on their versions
+- Add support for Python 3.12
 
 ### Removed
 - apiron no longer supports Python 3.7, which reached end of life on 2023-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated documentation to prefer `tox` usage
 - Updated documentation dependencies and removed upper bounds on their versions
 - Add support for Python 3.12
+- Remove upper bound on dependencies
 
 ### Removed
 - apiron no longer supports Python 3.7, which reached end of life on 2023-06-27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ package_dir = =src
 packages = find:
 include_package_data = True
 install_requires =
-    requests>=2.11.1,<3
-    urllib3>=1.26.13,<2
+    requests>=2.11.1
+    urllib3>=1.26.13
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     License :: OSI Approved :: MIT License
@@ -81,7 +82,7 @@ addopts = -ra --strict-markers --cov
 xfail_strict = True
 
 [tox:tox]
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 isolated_build = True
 
 [testenv]
@@ -115,6 +116,7 @@ deps =
     mypy
     typing_extensions
     types-requests
+    types-urllib3
 commands =
     mypy {posargs:src tests}
 passenv =


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [ ] Changelog up to date?

**What does this change address?**

Add support and trove classifiers for Python 3.12.

**How does this change work?**

- Add trove classifiers
- Add `tox` environment and test matrix entry
- Add constraint for `black`
- Fix missing type stubs for `urllib3`
