### PR TITLE
Modernize tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
 
 # Click through to this repository to see what other goodies are available
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace  # Removes trailing whitespace from lines in all file types
     -   id: end-of-file-fixer    # Fixes last line of all file types
@@ -22,22 +22,33 @@ repos:
     -   id: no-commit-to-branch  # Checks if you're committing to a disallowed branch
         args: [--branch, dev]
     -   id: check-ast            # Checks that Python files are valid syntax
+    -   id: check-toml # Checks TOML files for syntax errors
 
 ##########
 # Python #
 ##########
 
 # pyupgrade updates older syntax to newer syntax.
-# It's particularly handy for updating `.format()` calls to f-strings.
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v3.17.0
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py39-plus]
 
 # Run black last on Python code so all changes from previous hooks are reformatted
 -   repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 24.8.0
     hooks:
     -   id: black
-        language_version: python3.7
+        language_version: python3.9
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.1
+    hooks:
+    -   id: mypy
+        additional_dependencies: [typing_extensions, types-requests, types-urllib3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Modernize package quality tooling and configuration
 
 ## [8.0.0] - 2024-09-04
 ### Changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,4 +74,3 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ autodoc_default_options = {
     "members": True,
     "show-inheritance": True,
 }
-autodoc_mock_imports = []
+
 autoclass_content = "both"
 
 # Add any paths that contain templates here, relative to this directory.
@@ -129,23 +129,6 @@ html_sidebars = {"**": ["localtoc.html", "searchbox.html"]}
 # Output file base name for HTML help builder.
 htmlhelp_basename = "apirondoc"
 
-
-# -- Options for LaTeX output ------------------------------------------------
-
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 120
 target-version = ['py39', 'py310', 'py311', 'py312']
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,10 +103,12 @@ commands =
 skip_install = True
 deps =
     black
-    pyflakes
+    isort
+    ruff
 commands =
-    pyflakes {posargs:src tests}
-    black {posargs:--check src tests}
+    ruff check {posargs:src tests}
+    black {posargs:--check --diff src tests}
+    isort {posargs:--check --diff src tests}
 
 [testenv:typecheck]
 deps =

--- a/src/apiron/__init__.py
+++ b/src/apiron/__init__.py
@@ -1,6 +1,10 @@
 from apiron.client import Timeout
 from apiron.endpoint import Endpoint, JsonEndpoint, StreamingEndpoint, StubEndpoint
-from apiron.exceptions import APIException, NoHostsAvailableException, UnfulfilledParameterException
+from apiron.exceptions import (
+    APIException,
+    NoHostsAvailableException,
+    UnfulfilledParameterException,
+)
 from apiron.service import DiscoverableService, Service, ServiceBase
 
 __all__ = [

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
 import collections
 import logging
 import random
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib import parse
 
 import requests
@@ -11,6 +12,7 @@ from urllib3.util import retry
 
 if TYPE_CHECKING:
     import apiron  # pragma: no cover
+
 from apiron.exceptions import NoHostsAvailableException
 
 LOGGER = logging.getLogger(__name__)

--- a/src/apiron/endpoint/__init__.py
+++ b/src/apiron/endpoint/__init__.py
@@ -3,5 +3,4 @@ from apiron.endpoint.json import JsonEndpoint
 from apiron.endpoint.streaming import StreamingEndpoint
 from apiron.endpoint.stub import StubEndpoint
 
-
 __all__ = ["Endpoint", "JsonEndpoint", "StreamingEndpoint", "StubEndpoint"]

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -4,8 +4,9 @@ import logging
 import string
 import sys
 import warnings
+from collections.abc import Iterable
 from functools import partial, update_wrapper
-from typing import Any, Callable, Iterable, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover
     if sys.version_info >= (3, 10):
@@ -21,9 +22,8 @@ if TYPE_CHECKING:  # pragma: no cover
 import requests
 from urllib3.util import retry
 
-from apiron import client, Timeout
+from apiron import Timeout, client
 from apiron.exceptions import UnfulfilledParameterException
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/apiron/endpoint/json.py
+++ b/src/apiron/endpoint/json.py
@@ -1,5 +1,6 @@
 import collections
-from typing import Any, Dict, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from apiron.endpoint.endpoint import Endpoint
 
@@ -14,7 +15,7 @@ class JsonEndpoint(Endpoint):
         *args,
         path: str = "/",
         default_method: str = "GET",
-        default_params: Optional[Dict[str, Any]] = None,
+        default_params: Optional[dict[str, Any]] = None,
         required_params: Optional[Iterable[str]] = None,
         preserve_order: bool = False,
     ):
@@ -23,7 +24,7 @@ class JsonEndpoint(Endpoint):
         )
         self.preserve_order = preserve_order
 
-    def format_response(self, response) -> Dict[str, Any]:
+    def format_response(self, response) -> dict[str, Any]:
         """
         Extracts JSON data from the response
 
@@ -40,5 +41,5 @@ class JsonEndpoint(Endpoint):
         return response.json(object_pairs_hook=collections.OrderedDict if self.preserve_order else None)
 
     @property
-    def required_headers(self) -> Dict[str, str]:
+    def required_headers(self) -> dict[str, str]:
         return {"Accept": "application/json"}

--- a/src/apiron/endpoint/streaming.py
+++ b/src/apiron/endpoint/streaming.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from apiron.endpoint.endpoint import Endpoint
 

--- a/src/apiron/endpoint/stub.py
+++ b/src/apiron/endpoint/stub.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
 from apiron.endpoint import Endpoint
 

--- a/src/apiron/exceptions.py
+++ b/src/apiron/exceptions.py
@@ -1,6 +1,3 @@
-from typing import Set
-
-
 class APIException(Exception):
     pass
 
@@ -12,6 +9,6 @@ class NoHostsAvailableException(APIException):
 
 
 class UnfulfilledParameterException(APIException):
-    def __init__(self, endpoint_path: str, unfulfilled_params: Set[str]):
+    def __init__(self, endpoint_path: str, unfulfilled_params: set[str]):
         message = f"The {endpoint_path} endpoint was called without required parameters: {unfulfilled_params}"
         super().__init__(message)

--- a/src/apiron/service/__init__.py
+++ b/src/apiron/service/__init__.py
@@ -1,5 +1,4 @@
 from apiron.service.base import Service, ServiceBase
 from apiron.service.discoverable import DiscoverableService
 
-
 __all__ = ["Service", "ServiceBase", "DiscoverableService"]

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from apiron import Endpoint
 
 
 class ServiceMeta(type):
     @property
-    def required_headers(cls) -> Dict[str, str]:
+    def required_headers(cls) -> dict[str, str]:
         return cls().required_headers
 
     @property
-    def endpoints(cls) -> Set[Endpoint]:
+    def endpoints(cls) -> set[Endpoint]:
         return {attr for attr_name, attr in cls.__dict__.items() if isinstance(attr, Endpoint)}
 
     def __str__(cls) -> str:
@@ -20,12 +20,12 @@ class ServiceMeta(type):
 
 
 class ServiceBase(metaclass=ServiceMeta):
-    required_headers: Dict[str, Any] = {}
+    required_headers: dict[str, Any] = {}
     auth = ()
-    proxies: Dict[str, str] = {}
+    proxies: dict[str, str] = {}
 
     @classmethod
-    def get_hosts(cls) -> List[str]:
+    def get_hosts(cls) -> list[str]:
         """
         The fully-qualified hostnames that correspond to this service.
         These are often determined by asking a load balancer or service discovery mechanism.
@@ -48,7 +48,7 @@ class Service(ServiceBase):
     domain: str
 
     @classmethod
-    def get_hosts(cls) -> List[str]:
+    def get_hosts(cls) -> list[str]:
         """
         The fully-qualified hostnames that correspond to this service.
         These are often determined by asking a load balancer or service discovery mechanism.

--- a/src/apiron/service/discoverable.py
+++ b/src/apiron/service/discoverable.py
@@ -1,6 +1,11 @@
-from typing import List, Type
+from typing import Protocol
 
 from apiron.service.base import ServiceBase
+
+
+class Resolver(Protocol):
+    @staticmethod
+    def resolve(service_name: str) -> list[str]: ...
 
 
 class DiscoverableService(ServiceBase):
@@ -11,11 +16,11 @@ class DiscoverableService(ServiceBase):
     and returns a list of host names that correspond to that service.
     """
 
-    host_resolver_class: Type
+    host_resolver_class: type[Resolver]
     service_name: str
 
     @classmethod
-    def get_hosts(cls) -> List[str]:
+    def get_hosts(cls) -> list[str]:
         return cls.host_resolver_class.resolve(cls.service_name)
 
     def __str__(self) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from urllib3.util import retry
 
-from apiron import client, NoHostsAvailableException, Timeout
+from apiron import NoHostsAvailableException, Timeout, client
 
 
 @pytest.fixture


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [x] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

We want to keep relatively up to date with latest versions of tooling packages, language syntax, and internal practices and preferences.

**How does this change work?**

- Replace `pyflakes` with `ruff`
- Add `isort` to manage import ordering
- Update versions of `pre-commit` hooks and make parity with `tox` envs
- Run all hooks against all files
  - `isort` reordered imports
  - `pyupgrade` replaced primitives like `List`, `Dict`, and `Set` with
    their literals, allowed in Python 3.9+, removing need for imports
  - `pyupgrade` moved `Iterable` from `typing` to `collections.abc`
  - Fix type checking failures
    - Remove unused settings in `docs/conf.py`
    - Add `Protocol` for resolver classes
