### PR TITLE
Update documentation configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The master toctree document.
 master_doc = "index"
@@ -170,8 +170,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "requests": ("https://docs.python-requests.org/en/master/", None),
-    "urllib3": ("https://urllib3.readthedocs.io/en/latest/", None),
+    "requests": ("https://docs.python-requests.org/en/latest", None),
+    "urllib3": ("https://urllib3.readthedocs.io/en/latest", None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ commands = [
 [tool.tox.env.typecheck]
 deps = [
     { replace = "ref", of = ["tool", "tox", "env_run_base", "deps"], extend = true },
-    "mypy",
+    "mypy<1.12.0",  # https://github.com/python/mypy/issues/17960
     "typing_extensions",
     "types-requests",
     "types-urllib3",

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -45,7 +45,7 @@ class Service(ServiceBase):
     A service has a domain off of which one or more endpoints stem.
     """
 
-    domain: str
+    domain = "UNKNOWN"
 
     @classmethod
     def get_hosts(cls) -> list[str]:

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -45,7 +45,7 @@ class Service(ServiceBase):
     A service has a domain off of which one or more endpoints stem.
     """
 
-    domain = "UNKNOWN"
+    domain: str
 
     @classmethod
     def get_hosts(cls) -> list[str]:
@@ -61,7 +61,7 @@ class Service(ServiceBase):
         return [cls.domain]
 
     def __str__(self) -> str:
-        return self.__class__.domain
+        return getattr(self.__class__, "domain", "UNKNOWN")
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(domain={self.__class__.domain})"


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

The documentation build currently results in a few warnings, and consuming projects that were trying to build documentation which linked to apiron would fail, as Sphinx attempts to run `str(cls())` for referenced objects and the `__str__` method for `Service` would access `domain`, which is not set through an initializer but is instead expected to exist on the `Service` class definition before instantiation.

**How does this change work?**

- Use new data type for `source_suffix`
- Update intersphinx mappings to new locations
- Use fallback value for `domain` in `Service.__str__`