### PR TITLE
Fix type disagreement for `required_headers` in service code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.1] - 2025-06-04
+### Fixed
+- Fix type disagreement for `required_headers` in service code
+
 ## [8.0.0-post.1] - 2024-10-28
 ### Changed
 - Modernize package quality tooling and configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apiron"
-version = "8.0.0-post.1"
+version = "8.0.1"
 description = "apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP."
 authors = [
     { name = "Ithaka Harbors, Inc.", email = "opensource@ithaka.org" },

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from apiron import Endpoint
 
 
@@ -20,9 +18,20 @@ class ServiceMeta(type):
 
 
 class ServiceBase(metaclass=ServiceMeta):
-    required_headers: dict[str, Any] = {}
     auth = ()
     proxies: dict[str, str] = {}
+
+    @property
+    def required_headers(self) -> dict[str, str]:
+        """
+        The headers that are required to be present in requests to this service.
+
+        :return:
+            A dictionary of header names and their expected values
+        :rtype:
+            dict
+        """
+        return {}
 
     @classmethod
     def get_hosts(cls) -> list[str]:


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Consumers of `apiron` could run into type errors when overriding `required_headers` in a service they define.

- The `required_headers` attribute in `ServiceBase` is writeable, but consuming code that tried to override `required_headers` as a property would make `required_headers` read-only, which breaks the Liskov substitutability principle.
- The type of the `required_headers` attribute in `ServiceBase` was not as restrictive as the return type of the `required_headers` property in `ServiceMeta`, potentially leading to type disagreements in consuming code

**How does this change work?**

- Update `required_headers` in the `ServiceBase` class to be a property, matching the definition in `ServiceMeta` and making it overridable as a property in consuming code.
- Ensure the return type is as restrictive in `ServiceBase` as in `ServiceMeta`.