### PR TITLE
Defer on digital attestations for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,8 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false
 
       - name: Publish distribution to GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
**This change is a:** (check at least one)
- [x] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [x] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**

Attestations are preventing publishing. From [the publishing action docs](https://github.com/pypa/gh-action-pypi-publish):

> Support for generating and uploading [digital attestations](https://peps.python.org/pep-0740/) is currently experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI. Support for this feature is not yet stable; the settings and behavior described below may change without prior notice.

**How does this change work?**

Disable attestations for now.