### PR TITLE
Bump version again to get successful release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.2] - 2025-06-04
+### Fixed
+- Republish after deferring digital attestations to get around existing release artifacts from failed 8.0.1 release
+
 ## [8.0.1] - 2025-06-04
 ### Fixed
 - Fix type disagreement for `required_headers` in service code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apiron"
-version = "8.0.1"
+version = "8.0.2"
 description = "apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP."
 authors = [
     { name = "Ithaka Harbors, Inc.", email = "opensource@ithaka.org" },


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [ ] Code style update
- [ ] Refactor
- [x] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Because attestations failed during publishing, the release and its artifacts were actually successful to PyPI TEST so after fixing the attestations by deferral, we still couldn't actually publish 8.0.1 to PyPI proper. I've deleted the 8.0.1 release in Test PyPI and we'll roll forward to 8.0.2 instead.