### PR TITLE
Drop Python 3.9 support and use ruff for formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install tox
         run: python -m pip install tox
@@ -37,8 +37,6 @@ jobs:
             toxenv: 'py311'
           - version: '3.10'
             toxenv: 'py310'
-          - version: '3.9'
-            toxenv: 'py39'
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install tox
         run: python -m pip install tox
@@ -77,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install tox
         run: python -m pip install tox
@@ -85,7 +83,7 @@ jobs:
       - name: Build docs
         run: tox -e docs
 
-  publish:
+  publish_test:
     needs: [lint, test, typecheck, docs]
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
@@ -98,7 +96,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install pypa/build
         run: python -m pip install build
@@ -112,10 +110,30 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
 
+  publish_prod:
+    needs: [lint, test, typecheck, docs]
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install pypa/build
+        run: python -m pip install build
+
+      - name: Build distribution
+        run: python -m build --outdir dist/
+
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          attestations: false
           verbose: true
 
       - name: Publish distribution to GitHub release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,22 @@ on:
       - 'v*'
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: python -m pip install tox
+
+      - name: Run linting
+        run: tox -e format
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -84,7 +100,7 @@ jobs:
         run: tox -e docs
 
   publish_test:
-    needs: [lint, test, typecheck, docs]
+    needs: [format, lint, test, typecheck, docs]
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
@@ -111,7 +127,7 @@ jobs:
           verbose: true
 
   publish_prod:
-    needs: [lint, test, typecheck, docs]
+    needs: [format, lint, test, typecheck, docs]
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -38,7 +38,7 @@ jobs:
           - version: '3.10'
             toxenv: 'py310'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python.version }}
         uses: actions/setup-python@v5
@@ -54,7 +54,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -70,7 +70,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,7 +91,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -118,7 +118,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,8 @@ repos:
 # General use / built-ins #
 ###########################
 
-# Click through to this repository to see what other goodies are available
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace  # Removes trailing whitespace from lines in all file types
     -   id: end-of-file-fixer    # Fixes last line of all file types
@@ -22,33 +21,20 @@ repos:
     -   id: no-commit-to-branch  # Checks if you're committing to a disallowed branch
         args: [--branch, dev]
     -   id: check-ast            # Checks that Python files are valid syntax
-    -   id: check-toml # Checks TOML files for syntax errors
+    -   id: check-toml           # Checks TOML files for syntax errors
 
 ##########
 # Python #
 ##########
 
-# pyupgrade updates older syntax to newer syntax.
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
     hooks:
-    -   id: pyupgrade
-        args: [--py39-plus]
-
-# Run black last on Python code so all changes from previous hooks are reformatted
--   repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-    -   id: black
-        language_version: python3.9
-
--   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-    -   id: isort
+    -   id: ruff-check
+    -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.17.1
     hooks:
     -   id: mypy
         additional_dependencies: [typing_extensions, types-requests, types-urllib3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0] - 2025-08-19
+### Removed
+- apiron no longer supports Python 3.9, which reaches end of life on 2025-10-31
+
+### Changed
+- Replace black, isort, and pyupgrade with ruff and use more ruff linting rules
+
 ## [8.0.2] - 2025-06-04
 ### Fixed
 - Republish after deferring digital attestations to get around existing release artifacts from failed 8.0.1 release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018-2022 Ithaka Harbors, Inc.
+Copyright 2018-2025 Ithaka Harbors, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction,

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Please read our [contribution guidelines](./.github/CONTRIBUTING.md) before gett
 This package is available under the MIT license.
 For more information, [view the full license and copyright notice](./LICENSE).
 
-Copyright 2018-2022 Ithaka Harbors, Inc.
+Copyright 2018-2025 Ithaka Harbors, Inc.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,19 +13,20 @@
 #
 import datetime
 import importlib.metadata
-import os
 import sys
+from datetime import timezone
+from pathlib import Path
 
-REPO = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, REPO)
+REPO = Path.resolve(Path(__file__) / ".." / "..")
+sys.path.insert(0, str(REPO))
 
 # -- Project information -----------------------------------------------------
 
-CURRENT_YEAR = datetime.datetime.now().year
+CURRENT_YEAR = datetime.datetime.now(tz=timezone.utc).year
 ORG = "Ithaka Harbors, Inc."
 
 project = "apiron"
-copyright = f"2018–{CURRENT_YEAR} {ORG}"
+copyright = f"2018–{CURRENT_YEAR} {ORG}"  # noqa: A001, RUF001
 author = ORG
 
 RELEASE_VERSION = importlib.metadata.version("apiron")

--- a/docs/docs-meta.rst
+++ b/docs/docs-meta.rst
@@ -31,8 +31,8 @@ Use your favorite method to create a virtual environment and install the package
 .. code-block:: shell
 
     $ cd /path/to/apiron/
-    $ pyenv virtualenv 3.9.0 apiron  # pick your favorite virtual environment tool
-    $ pyenv local apiron
+    $ python -m venv .venv --prompt apiron
+    $ source .venv/bin/activate
     (apiron) $ pip install -e .[docs]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apiron"
-version = "8.0.2"
+version = "9.0.0"
 description = "apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP."
 authors = [
     { name = "Ithaka Harbors, Inc.", email = "opensource@ithaka.org" },
@@ -15,7 +15,6 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -54,15 +53,37 @@ exclude = ["tests*"]
 # Tool configuration #
 ######################
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = [
+    "A",
+    "B",
+    "C4",
+    "DTZ",
+    "E",
+    "F",
+    "I",
+    "ISC",
+    "LOG",
+    "PT",
+    "PTH",
+    "RUF",
+    "S",
+    "SIM",
+    "UP",
+]
+ignore = [
+    "E501",
+    "PT019",
+    "S101",
+    "S105",
+]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 show_error_context = true
 pretty = true
@@ -93,7 +114,7 @@ addopts = ["-ra", "--strict-markers", "--cov"]
 xfail_strict = true
 
 [tool.tox]
-envlist = ["py39", "py310", "py311", "py312", "py313"]
+envlist = ["py310", "py311", "py312", "py313"]
 isolated_build = true
 
 [tool.tox.env_run_base]
@@ -116,28 +137,33 @@ commands = [
     ["sphinx-build", "-b", "html", "docs", "{envtmpdir}/docs"]
 ]
 
-[tool.tox.env.lint]
+[tool.tox.env.format]
 skip_install = true
 deps = [
-    "black",
-    "isort",
     "ruff",
 ]
 commands = [
-    ["ruff", "check", { replace = "posargs", default = ["src", "tests"], extend = true }],
-    ["black", { replace = "posargs", default = ["--check", "--diff", "src", "tests"], extend = true }],
-    ["isort", { replace = "posargs", default = ["--check", "--diff", "src", "tests"], extend = true }],
+    ["ruff", "format", { replace = "posargs", default = ["src", "tests", "docs"], extend = true }],
+]
+
+[tool.tox.env.lint]
+skip_install = true
+deps = [
+    "ruff",
+]
+commands = [
+    ["ruff", "check", { replace = "posargs", default = ["src", "tests", "docs"], extend = true }],
 ]
 
 [tool.tox.env.typecheck]
 deps = [
     { replace = "ref", of = ["tool", "tox", "env_run_base", "deps"], extend = true },
-    "mypy<1.12.0",  # https://github.com/python/mypy/issues/17960
+    "mypy",
     "typing_extensions",
     "types-requests",
     "types-urllib3",
 ]
 commands = [
-    ["mypy", { replace = "posargs", default = ["src", "tests"], extend = true }],
+    ["mypy", { replace = "posargs", default = ["src", "tests", "docs"], extend = true }],
 ]
 passenv = ["TERM"]

--- a/src/apiron/__init__.py
+++ b/src/apiron/__init__.py
@@ -1,10 +1,6 @@
 from apiron.client import Timeout
 from apiron.endpoint import Endpoint, JsonEndpoint, StreamingEndpoint, StubEndpoint
-from apiron.exceptions import (
-    APIException,
-    NoHostsAvailableException,
-    UnfulfilledParameterException,
-)
+from apiron.exceptions import APIException, NoHostsAvailableException, UnfulfilledParameterException
 from apiron.service import DiscoverableService, Service, ServiceBase
 
 __all__ = [

--- a/src/apiron/client.py
+++ b/src/apiron/client.py
@@ -92,7 +92,7 @@ def _choose_host(service: apiron.Service) -> str:
     hosts = service.get_hosts()
     if not hosts:
         raise NoHostsAvailableException(getattr(service, "service_name", "UNKNOWN SERVICE"))
-    return random.choice(hosts)
+    return random.choice(hosts)  # noqa: S311
 
 
 def _build_request_object(
@@ -269,7 +269,10 @@ def call(
 
     response = adapted_session.send(
         request,
-        timeout=(timeout_spec_to_use.connection_timeout, timeout_spec_to_use.read_timeout),
+        timeout=(
+            timeout_spec_to_use.connection_timeout,
+            timeout_spec_to_use.read_timeout,
+        ),
         stream=getattr(endpoint, "streaming", False),
         allow_redirects=allow_redirects,
         proxies=adapted_session.proxies or service.proxies,

--- a/src/apiron/endpoint/endpoint.py
+++ b/src/apiron/endpoint/endpoint.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import logging
 import string
-import sys
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import partial, update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover
-    if sys.version_info >= (3, 10):
-        from typing import Concatenate, ParamSpec
-    else:
-        from typing_extensions import Concatenate, ParamSpec
+    from typing import Concatenate, ParamSpec
 
     from apiron.service import Service
 
@@ -167,7 +163,7 @@ class Endpoint:
 
         if empty_params:
             warnings.warn(
-                f"The {self.path} endpoint " f"was called with empty parameters: {empty_params}",
+                f"The {self.path} endpoint was called with empty parameters: {empty_params}",
                 RuntimeWarning,
                 stacklevel=6,
             )

--- a/src/apiron/endpoint/json.py
+++ b/src/apiron/endpoint/json.py
@@ -1,6 +1,6 @@
 import collections
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from apiron.endpoint.endpoint import Endpoint
 
@@ -15,12 +15,15 @@ class JsonEndpoint(Endpoint):
         *args,
         path: str = "/",
         default_method: str = "GET",
-        default_params: Optional[dict[str, Any]] = None,
-        required_params: Optional[Iterable[str]] = None,
+        default_params: dict[str, Any] | None = None,
+        required_params: Iterable[str] | None = None,
         preserve_order: bool = False,
     ):
         super().__init__(
-            path=path, default_method=default_method, default_params=default_params, required_params=required_params
+            path=path,
+            default_method=default_method,
+            default_params=default_params,
+            required_params=required_params,
         )
         self.preserve_order = preserve_order
 

--- a/src/apiron/endpoint/stub.py
+++ b/src/apiron/endpoint/stub.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from apiron.endpoint import Endpoint
 
@@ -14,7 +14,7 @@ class StubEndpoint(Endpoint):
     def __get__(self, instance, owner):
         return self.stub_response
 
-    def __init__(self, stub_response: Optional[Any] = None, **kwargs):
+    def __init__(self, stub_response: Any | None = None, **kwargs):
         """
         :param stub_response:
             A pre-baked response or response-determining function.

--- a/src/apiron/service/__init__.py
+++ b/src/apiron/service/__init__.py
@@ -1,4 +1,4 @@
 from apiron.service.base import Service, ServiceBase
 from apiron.service.discoverable import DiscoverableService
 
-__all__ = ["Service", "ServiceBase", "DiscoverableService"]
+__all__ = ["DiscoverableService", "Service", "ServiceBase"]

--- a/src/apiron/service/base.py
+++ b/src/apiron/service/base.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from apiron import Endpoint
 
 
@@ -19,7 +21,7 @@ class ServiceMeta(type):
 
 class ServiceBase(metaclass=ServiceMeta):
     auth = ()
-    proxies: dict[str, str] = {}
+    proxies: ClassVar[dict[str, str]] = {}
 
     @property
     def required_headers(self) -> dict[str, str]:

--- a/src/apiron/service/discoverable.py
+++ b/src/apiron/service/discoverable.py
@@ -28,6 +28,6 @@ class DiscoverableService(ServiceBase):
 
     def __repr__(self) -> str:
         klass = self.__class__
-        return "{klass}(service_name={service_name}, host_resolver={host_resolver})".format(
-            klass=klass.__name__, service_name=klass.service_name, host_resolver=klass.host_resolver_class.__name__
+        return (
+            f"{klass.__name__}(service_name={klass.service_name}, host_resolver={klass.host_resolver_class.__name__})"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import requests
 
 
 @pytest.fixture(autouse=True)
-def hobble_network(monkeypatch, request):
+def _hobble_network(monkeypatch, request):
     """Hobble all network calls made through the requests library"""
 
     if "no_hobble_network" in request.keywords:

--- a/tests/service/test_base.py
+++ b/tests/service/test_base.py
@@ -13,24 +13,24 @@ def service():
 
 class TestServiceBase:
     def test_get_hosts_returns_empty_list_by_default(self):
-        assert [] == ServiceBase.get_hosts()
+        assert ServiceBase.get_hosts() == []
 
     def test_required_headers_returns_empty_dict_by_default(self, service):
-        assert {} == service.required_headers
+        assert service.required_headers == {}
 
 
 class TestService:
     def test_get_hosts_returns_domain(self, service):
-        assert ["http://foo.com"] == service.get_hosts()
+        assert service.get_hosts() == ["http://foo.com"]
 
     def test_str_method_on_class(self, service):
-        assert "http://foo.com" == str(service)
+        assert str(service) == "http://foo.com"
 
     def test_repr_method_on_class(self, service):
-        assert "SomeService(domain=http://foo.com)" == repr(service)
+        assert repr(service) == "SomeService(domain=http://foo.com)"
 
     def test_required_headers_returns_empty_dict_by_default(self, service):
-        assert {} == service.required_headers
+        assert service.required_headers == {}
 
     def test_endpoints_when_no_endpoints(self, service):
         assert service.endpoints == set()

--- a/tests/service/test_discoverable.py
+++ b/tests/service/test_discoverable.py
@@ -21,10 +21,10 @@ def service():
 
 class TestDiscoverableService:
     def test_get_hosts_returns_hosts_from_resolver(self, service):
-        assert ["fake"] == service.get_hosts()
+        assert service.get_hosts() == ["fake"]
 
     def test_str_method_on_class(self, service):
-        assert "fake-service" == str(service)
+        assert str(service) == "fake-service"
 
     def test_repr_method_on_class(self, service):
-        assert "FakeService(service_name=fake-service, host_resolver=FakeResolver)" == repr(service)
+        assert repr(service) == "FakeService(service_name=fake-service, host_resolver=FakeResolver)"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -103,7 +103,7 @@ def test_build_request_object_passes_arguments_to_request_constructor(
             auth=auth,
         )
 
-        assert 1 == mock_prepare_request.call_count
+        assert mock_prepare_request.call_count == 1
 
 
 @mock.patch("apiron.client.Timeout")
@@ -157,7 +157,13 @@ def test_call(
     mock_endpoint.default_method = "POST"
     request.method = "POST"
 
-    client.call(service, mock_endpoint, session=mock_session, timeout_spec=mock_timeout, logger=mock_logger)
+    client.call(
+        service,
+        mock_endpoint,
+        session=mock_session,
+        timeout_spec=mock_timeout,
+        logger=mock_logger,
+    )
 
     mock_session.send.assert_any_call(
         request,
@@ -173,7 +179,12 @@ def test_call(
     request.method = "PUT"
 
     client.call(
-        service, mock_endpoint, method="PUT", session=mock_session, timeout_spec=mock_timeout, logger=mock_logger
+        service,
+        mock_endpoint,
+        method="PUT",
+        session=mock_session,
+        timeout_spec=mock_timeout,
+        logger=mock_logger,
     )
 
     mock_session.send.assert_any_call(
@@ -188,7 +199,13 @@ def test_call(
 @mock.patch("apiron.client._build_request_object")
 @mock.patch("apiron.client._adapt_session")
 @mock.patch("requests.Session", autospec=True)
-def test_call_auth_priority(MockSession, mock_adapt_session, mock_build_request_object, mock_endpoint, mock_logger):
+def test_call_auth_priority(
+    MockSession,
+    mock_adapt_session,
+    mock_build_request_object,
+    mock_endpoint,
+    mock_logger,
+):
     service = mock.Mock()
     service.get_hosts.return_value = ["http://host1.biz"]
     service.required_headers = {}
@@ -200,15 +217,30 @@ def test_call_auth_priority(MockSession, mock_adapt_session, mock_build_request_
 
     mock_adapt_session.return_value = mock_session
 
-    client.call(service, mock_endpoint, auth=("direct-user", "p455w0rd!"), session=mock_session, logger=mock_logger)
-    assert mock_build_request_object.call_args[1]["auth"] == ("direct-user", "p455w0rd!")
+    client.call(
+        service,
+        mock_endpoint,
+        auth=("direct-user", "p455w0rd!"),
+        session=mock_session,
+        logger=mock_logger,
+    )
+    assert mock_build_request_object.call_args[1]["auth"] == (
+        "direct-user",
+        "p455w0rd!",
+    )
 
     client.call(service, mock_endpoint, session=mock_session, logger=mock_logger)
-    assert mock_build_request_object.call_args[1]["auth"] == ("session-user", "p455w0rd!")
+    assert mock_build_request_object.call_args[1]["auth"] == (
+        "session-user",
+        "p455w0rd!",
+    )
 
     mock_session.auth = ()
     client.call(service, mock_endpoint, logger=mock_logger)
-    assert mock_build_request_object.call_args[1]["auth"] == ("service-user", "p455w0rd!")
+    assert mock_build_request_object.call_args[1]["auth"] == (
+        "service-user",
+        "p455w0rd!",
+    )
 
 
 def test_call_with_existing_session(mock_response, mock_endpoint, mock_logger):
@@ -232,16 +264,27 @@ def test_call_with_explicit_encoding(mock_response, mock_endpoint, mock_logger):
     session = mock.Mock()
     session.send.return_value = mock_response
 
-    client.call(service, mock_endpoint, session=session, logger=mock_logger, encoding="FAKE-CODEC")
+    client.call(
+        service,
+        mock_endpoint,
+        session=session,
+        logger=mock_logger,
+        encoding="FAKE-CODEC",
+    )
 
-    assert "FAKE-CODEC" == mock_response.encoding
+    assert mock_response.encoding == "FAKE-CODEC"
 
 
 @mock.patch("apiron.client._build_request_object")
 @mock.patch("apiron.client._adapt_session")
 @mock.patch("requests.Session", autospec=True)
 def test_call_uses_configured_endpoint_timeout_spec(
-    MockSession, mock_adapt_session, mock_build_request_object, mock_response, mock_endpoint, mock_logger
+    MockSession,
+    mock_adapt_session,
+    mock_build_request_object,
+    mock_response,
+    mock_endpoint,
+    mock_logger,
 ):
     service = mock.Mock()
     service.get_hosts.return_value = ["http://host1.biz"]
@@ -275,7 +318,12 @@ def test_call_uses_configured_endpoint_timeout_spec(
 @mock.patch("apiron.client.adapters.HTTPAdapter", autospec=True)
 @mock.patch("requests.Session", autospec=True)
 def test_call_uses_configured_endpoint_retry_spec(
-    MockSession, MockAdapter, mock_build_request_object, mock_response, mock_endpoint, mock_logger
+    MockSession,
+    MockAdapter,
+    mock_build_request_object,
+    mock_response,
+    mock_endpoint,
+    mock_logger,
 ):
     service = mock.Mock()
     service.get_hosts.return_value = ["http://host1.biz"]
@@ -334,7 +382,13 @@ def test_call_when_raw_response_object_requested(mock_response, mock_endpoint, m
     session = mock.Mock()
     session.send.return_value = mock_response
 
-    response = client.call(service, mock_endpoint, session=session, logger=mock_logger, return_raw_response_object=True)
+    response = client.call(
+        service,
+        mock_endpoint,
+        session=session,
+        logger=mock_logger,
+        return_raw_response_object=True,
+    )
 
     assert response is mock_response
 
@@ -376,7 +430,7 @@ def test_return_raw_response_object_in_call_overrides_endpoint(mock_response, mo
 
 
 @pytest.mark.parametrize(
-    "host,path,url",
+    ("host", "path", "url"),
     [
         ("http://biz.com", "/endpoint", "http://biz.com/endpoint"),
         ("http://biz.com/", "endpoint", "http://biz.com/endpoint"),

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -40,57 +40,59 @@ class TestEndpoint:
 
     def test_default_attributes_from_constructor(self):
         foo = apiron.Endpoint()
-        assert "/" == foo.path
-        assert "GET" == foo.default_method
+        assert foo.path == "/"
+        assert foo.default_method == "GET"
 
     def test_constructor_stores_passed_attributes(self):
         foo = apiron.Endpoint(path="/foo/", default_method="POST")
-        assert "/foo/" == foo.path
-        assert "POST" == foo.default_method
+        assert foo.path == "/foo/"
+        assert foo.default_method == "POST"
 
     def test_format_response(self):
         foo = apiron.Endpoint()
         mock_response = mock.Mock()
         mock_response.text = "foobar"
-        assert "foobar" == foo.format_response(mock_response)
+        assert foo.format_response(mock_response) == "foobar"
 
     def test_required_headers(self):
         foo = apiron.Endpoint()
-        assert {} == foo.required_headers
+        assert foo.required_headers == {}
 
     def test_path_placeholders_when_none_present(self):
         foo = apiron.Endpoint()
-        assert [] == foo.path_placeholders
+        assert foo.path_placeholders == []
 
     def test_path_placeholders_when_present(self):
         foo = apiron.Endpoint(path="/foo/{one}/{two}")
-        assert ["one", "two"] == foo.path_placeholders
+        assert foo.path_placeholders == ["one", "two"]
 
     def test_format_path_with_correct_kwargs(self):
         foo = apiron.Endpoint(path="/{one}/{two}/")
         path_kwargs = {"one": "foo", "two": "bar"}
-        assert "/foo/bar/" == foo.get_formatted_path(**path_kwargs)
+        assert foo.get_formatted_path(**path_kwargs) == "/foo/bar/"
 
     def test_format_path_with_incorrect_kwargs(self):
         foo = apiron.Endpoint(path="/{one}/{two}/")
         path_kwargs = {"foo": "bar"}
-        with pytest.warns(RuntimeWarning, match="An unknown path kwarg was supplied"):
-            with pytest.raises(KeyError):
-                foo.get_formatted_path(**path_kwargs)
+        with pytest.raises(KeyError), pytest.warns(RuntimeWarning, match="An unknown path kwarg was supplied"):
+            foo.get_formatted_path(**path_kwargs)
 
     def test_format_path_with_extra_kwargs(self):
         foo = apiron.Endpoint(path="/{one}/{two}/")
         path_kwargs = {"one": "foo", "two": "bar", "three": "not used"}
         with pytest.warns(RuntimeWarning, match="An unknown path kwarg was supplied"):
-            assert "/foo/bar/" == foo.get_formatted_path(**path_kwargs)
+            assert foo.get_formatted_path(**path_kwargs) == "/foo/bar/"
 
     def test_query_parameter_in_path_generates_warning(self):
-        with pytest.warns(UserWarning, match=r"Endpoint path \('/\?foo=bar'\) may contain query parameters"):
+        with pytest.warns(
+            UserWarning,
+            match=r"Endpoint path \('/\?foo=bar'\) may contain query parameters",
+        ):
             _ = apiron.Endpoint(path="/?foo=bar")
 
     def test_get_merged_params(self):
         foo = apiron.Endpoint(default_params={"foo": "bar"}, required_params={"baz"})
-        assert {"foo": "bar", "baz": "qux"} == foo.get_merged_params({"baz": "qux"})
+        assert foo.get_merged_params({"baz": "qux"}) == {"foo": "bar", "baz": "qux"}
 
     def test_get_merged_params_with_unsupplied_param(self):
         foo = apiron.Endpoint(default_params={"foo": "bar"}, required_params={"baz"})
@@ -101,11 +103,11 @@ class TestEndpoint:
     def test_get_merged_params_with_empty_param(self):
         foo = apiron.Endpoint(default_params={"foo": "bar"}, required_params={"baz"})
         with pytest.warns(RuntimeWarning, match="endpoint was called with empty parameters"):
-            assert {"foo": "bar", "baz": None} == foo.get_merged_params({"baz": None})
+            assert foo.get_merged_params({"baz": None}) == {"foo": "bar", "baz": None}
 
     def test_get_merged_params_with_required_and_default_param(self):
         foo = apiron.Endpoint(default_params={"foo": "bar"}, required_params={"foo"})
-        assert {"foo": "bar"} == foo.get_merged_params()
+        assert foo.get_merged_params() == {"foo": "bar"}
 
     def test_str_method(self):
         foo = apiron.Endpoint(path="/bar/baz")
@@ -123,7 +125,7 @@ class TestJsonEndpoint:
 
         with mock.patch.object(mock_response, "json") as mock_json:
             mock_json.return_value = {"foo": "bar"}
-            assert {"foo": "bar"} == foo.format_response(mock_response)
+            assert foo.format_response(mock_response) == {"foo": "bar"}
             mock_json.assert_called_once_with(object_pairs_hook=None)
 
     def test_format_response_when_ordered(self):
@@ -132,12 +134,12 @@ class TestJsonEndpoint:
 
         with mock.patch.object(mock_response, "json") as mock_json:
             mock_json.return_value = {"foo": "bar"}
-            assert {"foo": "bar"} == foo.format_response(mock_response)
+            assert foo.format_response(mock_response) == {"foo": "bar"}
             mock_json.assert_called_once_with(object_pairs_hook=collections.OrderedDict)
 
     def test_required_headers(self):
         foo = apiron.JsonEndpoint()
-        assert {"Accept": "application/json"} == foo.required_headers
+        assert foo.required_headers == {"Accept": "application/json"}
 
     def test_str_method(self):
         foo = apiron.JsonEndpoint(path="/bar/baz")
@@ -173,8 +175,11 @@ class TestStubEndpoint:
         assert service.stub_endpoint() == "stub response"
 
     @pytest.mark.parametrize(
-        "test_call_kwargs,expected_response",
-        [({}, {"default": "response"}), ({"params": {"param_key": "param_value"}}, {"stub response": "stubby!"})],
+        ("test_call_kwargs", "expected_response"),
+        [
+            ({}, {"default": "response"}),
+            ({"params": {"param_key": "param_value"}}, {"stub response": "stubby!"}),
+        ],
     )
     def test_call_dynamic(self, test_call_kwargs, expected_response, service, stub_function):
         service.stub_endpoint = apiron.StubEndpoint(stub_response=stub_function)


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [ ] Feature addition
- [x] Code style update
- [x] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [x] Yes
- [ ] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
Python 3.9 will be end of life shortly, on 2025-10-31.

**How does this change work?**

- Remove reference to and dependency on Python 3.9
- Split publishing into two jobs and add attestations back
- Update pre-commit hook versions and remove unused hooks
- Update copyright years
- Replace black, isort, and pyupgrade with ruff
- Add more ruff linting rules and fix violations
- Upgrade code to latest Python syntax