### PR TITLE
Enhance JsonEndpoint to support configurable timeouts, retries, and return of raw response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.1.0] - 2025-09-15
 ### Added
-- Added support configurable a timeout, retry policy, and raw response return for `JsonEndpoint`
+- Added support for a configurable timeout and retry spec, and raw response return for `JsonEndpoint`
 
 ## [9.0.0] - 2025-08-19
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] - 2025-09-15
+### Added
+- Added support configurable a timeout, retry policy, and raw response return for `JsonEndpoint`
+
 ## [9.0.0] - 2025-08-19
 ### Removed
 - apiron no longer supports Python 3.9, which reaches end of life on 2025-10-31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apiron"
-version = "9.0.0"
+version = "9.1.0"
 description = "apiron helps you cook a tasty client for RESTful APIs. Just don't wash it with SOAP."
 authors = [
     { name = "Ithaka Harbors, Inc.", email = "opensource@ithaka.org" },

--- a/src/apiron/endpoint/json.py
+++ b/src/apiron/endpoint/json.py
@@ -2,9 +2,10 @@ import collections
 from collections.abc import Iterable
 from typing import Any
 
+from urllib3.util import retry
+
 from apiron import Timeout
 from apiron.endpoint.endpoint import Endpoint
-from urllib3.util import retry
 
 
 class JsonEndpoint(Endpoint):

--- a/src/apiron/endpoint/json.py
+++ b/src/apiron/endpoint/json.py
@@ -2,7 +2,9 @@ import collections
 from collections.abc import Iterable
 from typing import Any
 
+from apiron import Timeout
 from apiron.endpoint.endpoint import Endpoint
+from urllib3.util import retry
 
 
 class JsonEndpoint(Endpoint):
@@ -18,12 +20,18 @@ class JsonEndpoint(Endpoint):
         default_params: dict[str, Any] | None = None,
         required_params: Iterable[str] | None = None,
         preserve_order: bool = False,
+        return_raw_response_object: bool = False,
+        timeout_spec: Timeout | None = None,
+        retry_spec: retry.Retry | None = None,
     ):
         super().__init__(
             path=path,
             default_method=default_method,
             default_params=default_params,
             required_params=required_params,
+            return_raw_response_object=return_raw_response_object,
+            timeout_spec=timeout_spec,
+            retry_spec=retry_spec,
         )
         self.preserve_order = preserve_order
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -2,6 +2,7 @@ import collections
 from unittest import mock
 
 import pytest
+from urllib3.util import retry
 
 import apiron
 
@@ -149,6 +150,22 @@ class TestJsonEndpoint:
         foo = apiron.JsonEndpoint(path="/bar/baz")
         assert repr(foo) == "JsonEndpoint(path='/bar/baz')"
 
+    def test_timeout_spec_parameter(self):
+        """Test that JsonEndpoint accepts and stores timeout_spec parameter"""
+        timeout_spec = apiron.Timeout(connection_timeout=5, read_timeout=10)
+        foo = apiron.JsonEndpoint(timeout_spec=timeout_spec)
+        assert foo.timeout_spec == timeout_spec
+
+    def test_retry_spec_parameter(self):
+        """Test that JsonEndpoint accepts and stores retry_spec parameter"""
+        retry_spec = retry.Retry(total=3, backoff_factor=1)
+        foo = apiron.JsonEndpoint(retry_spec=retry_spec)
+        assert foo.retry_spec == retry_spec
+
+    def test_return_raw_response_object_parameter(self):
+        """Test that JsonEndpoint accepts and stores return_raw_response_object parameter"""
+        foo = apiron.JsonEndpoint(return_raw_response_object=True)
+        assert foo.return_raw_response_object is True
 
 class TestStreamingEndpoint:
     def test_format_response(self):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -151,19 +151,16 @@ class TestJsonEndpoint:
         assert repr(foo) == "JsonEndpoint(path='/bar/baz')"
 
     def test_timeout_spec_parameter(self):
-        """Test that JsonEndpoint accepts and stores timeout_spec parameter"""
         timeout_spec = apiron.Timeout(connection_timeout=5, read_timeout=10)
         foo = apiron.JsonEndpoint(timeout_spec=timeout_spec)
         assert foo.timeout_spec == timeout_spec
 
     def test_retry_spec_parameter(self):
-        """Test that JsonEndpoint accepts and stores retry_spec parameter"""
         retry_spec = retry.Retry(total=3, backoff_factor=1)
         foo = apiron.JsonEndpoint(retry_spec=retry_spec)
         assert foo.retry_spec == retry_spec
 
     def test_return_raw_response_object_parameter(self):
-        """Test that JsonEndpoint accepts and stores return_raw_response_object parameter"""
         foo = apiron.JsonEndpoint(return_raw_response_object=True)
         assert foo.return_raw_response_object is True
 


### PR DESCRIPTION
**This change is a:** (check at least one)
- [ ] Bugfix
- [x] Feature addition
- [ ] Code style update
- [ ] Refactor
- [ ] Release activity

**Is this a breaking change?** (check one)
- [ ] Yes
- [x] No

**Is the:**
- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite passing?
- [x] Code coverage maximal?
- [x] Changelog up to date?

**What does this change address?**
This PR addresses: https://github.com/ithaka/apiron/issues/152

While `JSONEndpoint` inherits from `Endpoint`, it does not pass through parameters required for configuring timeouts, retries, or return of raw response. This PR ensures those get passed through effectively reaching feature parity with it's parent class.

